### PR TITLE
Add Group Name and Abbreviation to CSV

### DIFF
--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -112,7 +112,7 @@
                     </li>
                 </ul>
                 <div class="tab-content" id="myTabContent">
-                    
+
                     <div v-for="(officialCategory, index) in officialRoleCategories" :key="index" class="tab-pane fade" :id="officialCategory" role="tabpanel" aria-labelledby="officialCategory + '-tab'" :class="{ 'show active': index === 0 }">
                         <ul class="list-group list-group-flush">
                                 <li class="list-group-item" v-for="officialRole in rolesForOfficialCategory(officialCategory)" :key="officialRole.id">
@@ -121,7 +121,7 @@
 
                     </div>
                 </div>
-                
+
         </div>
 
     </div>
@@ -230,7 +230,6 @@
                 }).join(", ");
             },
             csvlist() {
-                // name, group, role,
                 return this.filteredList.map((member) => ({
                     group_title: member.group.group_title,
                     group_abbr: member.group.abbreviation,

--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -233,19 +233,18 @@
                 return this.filteredList.map((member) => ({
                     group_title: member.group.group_title,
                     group_abbr: member.group.abbreviation,
-                    group_id: member.group.id,
+                    group_link: `${window.location.origin}/groups/${member.group.id}`,
                     role: member.role.label,
                     surname: member.user.surname,
-                    "given name": member.user.givenname,
+                    given_name: member.user.givenname,
                     email: member.user.email,
-                    role: member.role.label,
+                    title: member.user.title,
                     notes: member.notes,
-                    "start date": member.start_date,
-                    "end date": member.end_date,
                     office: member.user.office
                         ? member.user.office.replace(/ \$ /g, "\n")
                         : "",
-                    title: member.user.title
+                    start_date: member.start_date,
+                    end_date: member.end_date,
                 }));
             }
         },

--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -229,35 +229,25 @@
                     return arr.indexOf(elem) == pos;
                 }).join(", ");
             },
-            csvlist: function () {
-                var targetList = this.members;
-                if (this.filterList) {
-                    targetList = this.members.filter(e => e.filtered);
-                }
-                const rows = targetList.map(r => {
-                    return {
-                        "surname": r.user.surname,
-                        "given name": r.user.givenname,
-                        "email": r.user.email,
-                        "role": r.role.label,
-                        "notes": r.notes,
-                        "start date": r.start_date,
-                        "end date": r.end_date,
-                        "office": r.user.office?r.user.office.replace(/ \$ /g, "\n"):null,
-                        "title": r.user.title
-                    }
-                });
-                return rows;
-                // let row_str = 'Surname, GivenName, Label, Notes, Start Date, End Date\n'
-                // row_str += rows.join('\n');
-
-                // console.log(row_str);
-
-                // const link = document.createElement("a");
-                // const file = new Blob([row_str], {type: 'text/csv'});
-                // link.href = URL.createObjectURL(file);
-                // link.download = '' + this.group.group_title + '.csv';
-                // link.click();
+            csvlist() {
+                // name, group, role,
+                return this.filteredList.map((member) => ({
+                    group_title: member.group.group_title,
+                    group_abbr: member.group.abbreviation,
+                    group_id: member.group.id,
+                    role: member.role.label,
+                    surname: member.user.surname,
+                    "given name": member.user.givenname,
+                    email: member.user.email,
+                    role: member.role.label,
+                    notes: member.notes,
+                    "start date": member.start_date,
+                    "end date": member.end_date,
+                    office: member.user.office
+                        ? member.user.office.replace(/ \$ /g, "\n")
+                        : "",
+                    title: member.user.title
+                }));
             }
         },
         methods: {


### PR DESCRIPTION
Adds group info to CSV member export:
- group name
- group abbrevation
- link to group

Resolves #5 

I like the suggestion to add UMN official group codes (e.g. dept numbers) to a group and including this in the CSV export, but I wasn't sure if this info is in bluesheet.

[Example CSV Export](https://docs.google.com/spreadsheets/d/1brmO-KQ8ljsAdqM7l3l6PD2uCwHGUI4pSFk2XOvOdfU/edit?usp=sharing)

<a href="https://docs.google.com/spreadsheets/d/1brmO-KQ8ljsAdqM7l3l6PD2uCwHGUI4pSFk2XOvOdfU/edit?usp=sharing">
<img width="400" alt="Screen Shot 2022-06-07 at 10 33 04 PM" src="https://user-images.githubusercontent.com/980170/172525992-e6b49feb-f798-4ff6-ad2c-5332c004212f.png">
</a>

