### PR TITLE
Remove underscore from leave types

### DIFF
--- a/resources/js/components/LeaveChip.vue
+++ b/resources/js/components/LeaveChip.vue
@@ -21,7 +21,7 @@
           'tw-line-through': leave.status === 'cancelled',
         }"
       >
-        {{ leave.type }} Leave
+        {{ prettyLeaveType }} Leave
       </span>
     </header>
 
@@ -52,6 +52,8 @@ const props = defineProps<{
 }>();
 
 const isOpen = ref(false);
+
+const prettyLeaveType = computed(() => props.leave.type.replace(/_/g, " "));
 
 const statusColor = computed(() => {
   switch (props.leave.status) {


### PR DESCRIPTION
This removes underscores when rendering leave types, so `COURSE_RELEASE LEAVE` becomes `COURSE RELEASE LEAVE`
<img width="500" alt="ScreenShot 2023-09-01 at 11 15 07@2x" src="https://github.com/UMN-LATIS/bluesheet/assets/980170/30cb0417-e91f-4dc7-b9f9-16974132d638">

Fixes #48