### PR TITLE
Fix: instructors with "Unspecified"  appointments appearing even when "Unspecified" was unchecked

### DIFF
--- a/app/Http/Resources/CourseWithInstructors.php
+++ b/app/Http/Resources/CourseWithInstructors.php
@@ -4,6 +4,12 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
+function trimWithFallback($string, $default = 'Unspecified') {
+    if (!is_string($string)) return $default;
+    $trimmedString = trim($string);
+    return $trimmedString ? $trimmedString : $default;
+}
+
 class CourseWithInstructors extends JsonResource {
     /**
      * Transform the resource into an array.
@@ -24,8 +30,8 @@ class CourseWithInstructors extends JsonResource {
             "enrollmentTotal" => $this->ENROLLMENT_TOTAL,
             "instructorRole" => $this->INSTRUCTOR_ROLE,
             "cancelled" => (bool) $this->CANCELLED,
-            "componentType" => $this->COMPONENT_CLASS,
-            "academicCareer" => $this->ACADEMIC_CAREER,
+            "courseType" => trimWithFallback($this->COMPONENT_CLASS),
+            "courseLevel" => trimWithFallback($this->ACADEMIC_CAREER),
             "instructor" => $this->instructor ? [
                 'id' => $this->instructor->id,
                 'givenName' => $this->instructor->givenname,
@@ -33,7 +39,7 @@ class CourseWithInstructors extends JsonResource {
                 'displayName' => $this->instructor->displayName,
                 'email' => $this->instructor->email,
                 'leaves' => $this->when($this->instructor->leaves->isNotEmpty(), $this->instructor->leaves),
-                'jobCategory' => $this->instructor->jobCategory,
+                'academicAppointment' => trimWithFallback($this->instructor->jobCategory),
                 'emplid' => $this->instructor->emplid,
             ] : null,
         ];

--- a/resources/js/api.ts
+++ b/resources/js/api.ts
@@ -65,20 +65,6 @@ export async function getTerms() {
   return res.data;
 }
 
-const NULL_PLACEHOLDER = "Unspecified";
-function normalizeCourse(course: Course) {
-  return {
-    ...course,
-    academicCareer: course.courseLevel?.trim() || NULL_PLACEHOLDER,
-    componentType: course.courseType?.trim() || NULL_PLACEHOLDER,
-    instructor: {
-      ...course.instructor,
-      jobCategory:
-        course.instructor.academicAppointment?.trim() || NULL_PLACEHOLDER,
-    },
-  };
-}
-
 export async function getGroupCoursesByTerm({
   groupId,
   termId,
@@ -90,7 +76,7 @@ export async function getGroupCoursesByTerm({
     `/api/terms/${termId}/groups/${groupId}/courses?includeRoles=PI`,
   );
 
-  return res.data.map(normalizeCourse);
+  return res.data;
 }
 
 export async function getGroup(groupId: number) {

--- a/resources/js/api.ts
+++ b/resources/js/api.ts
@@ -65,6 +65,20 @@ export async function getTerms() {
   return res.data;
 }
 
+const NULL_PLACEHOLDER = "Unspecified";
+function normalizeCourse(course: Course) {
+  return {
+    ...course,
+    academicCareer: course.courseLevel?.trim() || NULL_PLACEHOLDER,
+    componentType: course.courseType?.trim() || NULL_PLACEHOLDER,
+    instructor: {
+      ...course.instructor,
+      jobCategory:
+        course.instructor.academicAppointment?.trim() || NULL_PLACEHOLDER,
+    },
+  };
+}
+
 export async function getGroupCoursesByTerm({
   groupId,
   termId,
@@ -76,7 +90,7 @@ export async function getGroupCoursesByTerm({
     `/api/terms/${termId}/groups/${groupId}/courses?includeRoles=PI`,
   );
 
-  return res.data;
+  return res.data.map(normalizeCourse);
 }
 
 export async function getGroup(groupId: number) {

--- a/resources/js/pages/reports/SchedulingReport/ReportRow.vue
+++ b/resources/js/pages/reports/SchedulingReport/ReportRow.vue
@@ -14,7 +14,7 @@
       </RouterLink>
       <div class="tw-text-xs tw-text-neutral-400">
         {{ instructor.emplid }} •
-        {{ instructor.jobCategory?.trim() || nullValuePlaceholder }}
+        {{ instructor.academicAppointment }}
       </div>
     </Td>
     <Td
@@ -68,7 +68,6 @@ defineProps<{
   listOfTermLeaves: Leave[][];
   isShowingCourse: (course: Course) => boolean;
   currentTerm: Term | null;
-  nullValuePlaceholder?: string;
 }>();
 
 function doesInstructorNameMatchSearchTerm(

--- a/resources/js/pages/reports/SchedulingReport/SchedulingReportPage.vue
+++ b/resources/js/pages/reports/SchedulingReport/SchedulingReportPage.vue
@@ -196,7 +196,6 @@
               getInstructorTermCourses(instructor, term),
             )
           "
-          :nullValuePlaceholder="NULL_VALUE_PLACEHOLDER"
           :listOfTermLeaves="
             termsForReport.map((term) =>
               selectInstructorTermLeaves(instructor, term),
@@ -235,7 +234,6 @@ type TermId = number;
 const DEFAULT_START_DATE = dayjs().subtract(3, "year").format("YYYY-MM-DD");
 const DEFAULT_END_DATE = dayjs().add(2, "year").format("YYYY-MM-DD");
 const MAX_TERM_DATE = dayjs().add(3, "year").format("YYYY-MM-DD");
-const NULL_VALUE_PLACEHOLDER = "Unspecified";
 
 const tableRef = ref<HTMLElement>();
 const group = ref<Group>();
@@ -327,21 +325,15 @@ const instructorsWithinReportedTerms = computed(() => {
 });
 
 function isIncludedInstructorAppointment(instructor: Instructor) {
-  return !excludedInstAppointments.value.has(
-    instructor.jobCategory ?? NULL_VALUE_PLACEHOLDER,
-  );
+  return !excludedInstAppointments.value.has(instructor.academicAppointment);
 }
 
 function getAllCourseLevelsMap() {
   const allCourses: Course[] = [...coursesByTermMap.value.values()].flat();
   const courseLevels = new Map<string, number>();
   allCourses.forEach((course) => {
-    const currentCount =
-      courseLevels.get(course.academicCareer ?? NULL_VALUE_PLACEHOLDER) ?? 0;
-    courseLevels.set(
-      course.academicCareer ?? NULL_VALUE_PLACEHOLDER,
-      currentCount + 1,
-    );
+    const currentCount = courseLevels.get(course.courseLevel) ?? 0;
+    courseLevels.set(course.courseLevel, currentCount + 1);
   });
   return courseLevels;
 }
@@ -350,12 +342,8 @@ function getAllCourseTypesMap() {
   const allCourses: Course[] = [...coursesByTermMap.value.values()].flat();
   const courseTypes = new Map<string, number>();
   allCourses.forEach((course) => {
-    const currentCount =
-      courseTypes.get(course.componentType ?? NULL_VALUE_PLACEHOLDER) ?? 0;
-    courseTypes.set(
-      course.componentType ?? NULL_VALUE_PLACEHOLDER,
-      currentCount + 1,
-    );
+    const currentCount = courseTypes.get(course.courseType) ?? 0;
+    courseTypes.set(course.courseType, currentCount + 1);
   });
   return courseTypes;
 }
@@ -364,10 +352,9 @@ function getAllInstructorCategoriesMap() {
   const allInstructors = [...getInstructorsMap().values()];
   const instructorCategories = new Map<string, number>();
   allInstructors.forEach((instructor) => {
-    const jobCategory =
-      instructor.jobCategory?.trim() || NULL_VALUE_PLACEHOLDER;
-    const currentCount = instructorCategories.get(jobCategory) ?? 0;
-    instructorCategories.set(jobCategory, currentCount + 1);
+    const currentCount =
+      instructorCategories.get(instructor.academicAppointment) ?? 0;
+    instructorCategories.set(instructor.academicAppointment, currentCount + 1);
   });
   return instructorCategories;
 }
@@ -473,12 +460,8 @@ function sortCoursesByCourseNumber(a: Course, b: Course) {
 
 function isShowingCourse(course: Course) {
   return (
-    !excludedCourseTypes.value.has(
-      course.componentType ?? NULL_VALUE_PLACEHOLDER,
-    ) &&
-    !excludedCourseLevels.value.has(
-      course.academicCareer ?? NULL_VALUE_PLACEHOLDER,
-    )
+    !excludedCourseTypes.value.has(course.courseType) &&
+    !excludedCourseLevels.value.has(course.courseLevel)
   );
 }
 

--- a/resources/js/pages/reports/SchedulingReport/SchedulingReportPage.vue
+++ b/resources/js/pages/reports/SchedulingReport/SchedulingReportPage.vue
@@ -43,7 +43,7 @@
             </Button>
           </div>
           <label
-            v-for="[category, count] in instructorCategoriesMap.entries()"
+            v-for="[category, count] in sortedAppointmentTypeFilters"
             :key="category"
             class="tw-flex tw-items-center tw-text-sm gap-1"
           >
@@ -77,7 +77,7 @@
             >
           </div>
           <label
-            v-for="[courseType, count] in courseTypesMap.entries()"
+            v-for="[courseType, count] in sortedCourseTypes"
             :key="courseType"
             class="tw-flex tw-items-center tw-text-sm gap-1"
           >
@@ -221,7 +221,6 @@ import SelectGroup from "@/components/SelectGroup.vue";
 import pMap from "p-map";
 import Button from "@/components/Button.vue";
 import ReportRow from "./ReportRow.vue";
-import { PostIt } from "@umn-latis/cla-vue-template";
 import WideLayout from "@/layouts/WideLayout.vue";
 
 const props = defineProps<{
@@ -276,6 +275,18 @@ const currentTerm = computed((): Term | null => {
   });
 
   return currentTerm ?? null;
+});
+
+function sortEntriesByKey(a, b) {
+  return a[0].localeCompare(b[0]);
+}
+
+const sortedAppointmentTypeFilters = computed(() => {
+  return [...instructorCategoriesMap.value.entries()].sort(sortEntriesByKey);
+});
+
+const sortedCourseTypes = computed(() => {
+  return [...courseTypesMap.value.entries()].sort(sortEntriesByKey);
 });
 
 // not making these computed to avoid reactivity lag

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -199,7 +199,7 @@ export interface Instructor {
   displayName: string;
   email: string;
   leaves?: Leave[];
-  jobCategory: string | null; // "Faculty"
+  academicAppointment: string; // "Faculty"
 }
 
 export type TermCode = "FA" | "SP" | "SU";
@@ -216,8 +216,8 @@ export interface Course {
   enrollmentCap: number;
   enrollmentTotal: number;
   cancelled: boolean;
-  componentType: string; // "LEC"
-  academicCareer: string; //"UGRD" | "GRAD";
+  courseType: string; // "LEC"
+  courseLevel: string; //"UGRD" | "GRAD";
   instructor: Instructor;
 }
 


### PR DESCRIPTION
This resolves two issues I noticed when looking at the scheduling report for Writing Studies:
- Instructors with "Unspecified" appointments would show up even when the "Unspecified" filter was unchecked
- Appointment and course types were in a random non-alphabetical order.

<img width="500" src="https://github.com/UMN-LATIS/bluesheet/assets/980170/e36dbc93-ae73-4efa-979c-a125d29cc079" alt="4 instructors appear even when all instructor types unchecked" />

These instructors had a space in their appt type, and the logic for trimming and binning with the other nulls wasn't quite right because it used nullish coalescing (`??`) instead of "or" (`||`) to fallback.

Handling all the trimming and fallback logic in the view layer was fussy, so this PR moves the fallback work upstream into the api layer. 

Additionally, instructor appointment types and course types are now sorted alphabetically.

Up on dev:  https://cla-groups-dev.oit.umn.edu/reports/schedulingReport/24

With PR, delecting all appt types properly shows now instructors (and appt types are sorted properly):
<img width="500" alt="ScreenShot 2023-09-11 at 14 30 53@2x" src="https://github.com/UMN-LATIS/bluesheet/assets/980170/6f2ad08d-836d-4d4a-ba63-e93380bfefb9">
