### PR TITLE
differentiate breadcrumb + search input on Browse Groups page

### DIFF
--- a/resources/js/pages/GroupListPage.vue
+++ b/resources/js/pages/GroupListPage.vue
@@ -1,49 +1,34 @@
 <template>
   <DefaultLayout>
     <div>
-      <div class="row">
-        <div class="col-10">
-          <nav class="breadcrumb">
-            <router-link
-              v-for="breadcrumb in breadCrumbs"
-              :key="breadcrumb.title"
-              class="breadcrumb-item"
-              :to="{ path: breadcrumb.path }"
-              activeClass="active"
-              exactActiveClass=""
-              exact
-              >{{ breadcrumb.title }}</router-link
-            >
-          </nav>
-        </div>
-        <div class="col-2 p-1">
+      <div class="tw-flex tw-flex-wrap tw-justify-between tw-items-baseline">
+        <nav class="breadcrumb tw-bg-transparent tw-font-semibold tw-m-0">
+          <router-link
+            v-for="breadcrumb in breadCrumbs"
+            :key="breadcrumb.title"
+            class="breadcrumb-item tw-text-neutral-500 hover:tw-text-bs-blue tw-text-sm"
+            :to="{ path: breadcrumb.path }"
+            activeClass="active"
+            exactActiveClass=""
+            exact
+            >{{ breadcrumb.title }}</router-link
+          >
+        </nav>
+        <label>
+          <span class="sr-only">Search</span>
           <input
             v-model="searchTerm"
             type="text"
-            class="form-control"
+            class="tw-form-input tw-border tw-border-neutral-300 tw-rounded tw-text-sm"
             placeholder="Search"
           />
-        </div>
+        </label>
       </div>
-
-      <!-- <table class="table" v-if="currentOrganizations.length > 0">
-            <thead>
-                <tr>
-                    <th scope="col">Groups</th>
-              </tr>
-          </thead>
-          <tbody>
-                <tr v-for="currentOrg in currentOrganizations" :key="currentOrg.id" >
-                <td><router-link :to='{ path: "/groups/" + currentOrg.id }'>{{ currentOrg.label }}</router-link>
-                </td>
-            </tr>
-          </tbody>
-         </table> -->
 
       <table v-if="groupList" class="table">
         <thead>
           <tr>
-            <th scope="col">Groups</th>
+            <th scope="col" class="sr-only">Groups</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
Resolves #12

On the browse groups page, the breadcrumb box can read as a search input and the search input can read as a button to new users. This removes the background on the breadcrumbs and increases  the width of the search input a little:

Before:
<img width="400" alt="ScreenShot 2023-09-12 at 09 16 19@2x" src="https://github.com/UMN-LATIS/bluesheet/assets/980170/f8bf43db-cb10-49e4-aa18-cf74163d136e">

After:
<img width="400" alt="ScreenShot 2023-09-12 at 09 16 37@2x" src="https://github.com/UMN-LATIS/bluesheet/assets/980170/dbcdd277-702c-42d7-b1b7-87fb404ed8a7">
