### PR TITLE
Fix: autocomplete clicking in safari

### DIFF
--- a/resources/js/components/PersonSearch.vue
+++ b/resources/js/components/PersonSearch.vue
@@ -1,10 +1,12 @@
 <template>
   <div ref="personSearchContainer" class="person-search">
     <input
+      name="safari-autofill-fix"
       v-bind="$attrs"
       :value="modelValue"
       :class="inputClass"
       class="person-search__input form-control"
+      autocorrect="off"
       autocomplete="off"
       @input="handleInput"
       @focus="isMenuOpen = true"

--- a/resources/js/components/UserLookup.vue
+++ b/resources/js/components/UserLookup.vue
@@ -1,20 +1,22 @@
 <template>
   <Modal :show="show" @close="close">
-    <div class="row">
-      <label for="lookup" class="col-sm-3 col-form-label">Name:</label>
-      <div class="col-sm-6">
-        <PersonSearch
-          id="lookup"
-          v-model="userLookupText"
-          @selected="handleUserSelected"
-        />
-        <small id="addUserHelpBlock" class="form-text text-muted">
-          Optional: Enter a name and select the person from the list. For common
-          names, we recommend using internet ID (below) to be sure you get the
-          right person.
-        </small>
+    <form autocomplete="off">
+      <div class="row">
+        <label for="lookup" class="col-sm-3 col-form-label">Name:</label>
+        <div class="col-sm-6">
+          <PersonSearch
+            id="lookup"
+            v-model="userLookupText"
+            @selected="handleUserSelected"
+          />
+          <small id="addUserHelpBlock" class="form-text text-muted">
+            Optional: Enter a name and select the person from the list. For
+            common names, we recommend using internet ID (below) to be sure you
+            get the right person.
+          </small>
+        </div>
       </div>
-    </div>
+    </form>
 
     <div class="row">
       <label for="internetId" class="col-sm-3 col-form-label"

--- a/resources/js/components/UserLookup.vue
+++ b/resources/js/components/UserLookup.vue
@@ -1,9 +1,13 @@
 <template>
   <Modal :show="show" @close="close">
     <div class="row">
-      <label for="nameLookup" class="col-sm-3 col-form-label">Name:</label>
+      <label for="lookup" class="col-sm-3 col-form-label">Name:</label>
       <div class="col-sm-6">
-        <PersonSearch v-model="userLookupText" @selected="handleUserSelected" />
+        <PersonSearch
+          id="lookup"
+          v-model="userLookupText"
+          @selected="handleUserSelected"
+        />
         <small id="addUserHelpBlock" class="form-text text-muted">
           Optional: Enter a name and select the person from the list. For common
           names, we recommend using internet ID (below) to be sure you get the


### PR DESCRIPTION
Background:
When typing in the person search field, the dropdown appears with a list of buttons that are choices to complete the user.

The intended functionality is: when there's there's no focus within the person search, the menu should disappear. This was accomplished with CSS:
```
.person-search:not(:focus-within) .person-search__results {
  display: none;
}
```

This works well in Chrome and Firefox. But,[Safari behaves differently](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus). Clicking a button doesn't give the button focus in safari. Since the clicked button has no focus, there's no focus within the person search component thus hiding the list of options before the click lands.

So, the pithy CSS has to go. This PR reworks the component to use JS to open/close the person search.

On dev for testing.