### PR TITLE
Scheduling Report viewer can choose `TA` or `PI` roles for report

### DIFF
--- a/resources/js/api.ts
+++ b/resources/js/api.ts
@@ -9,6 +9,7 @@ import {
   Course,
   Term,
   Group,
+  InstructorRole,
 } from "@/types";
 
 export async function lookupUsers(query: string): Promise<UserLookupItem[]> {
@@ -68,12 +69,19 @@ export async function getTerms() {
 export async function getGroupCoursesByTerm({
   groupId,
   termId,
+  roles,
 }: {
   groupId: number;
   termId: number;
+  roles: InstructorRole[];
 }) {
   const res = await axios.get<Course[]>(
-    `/api/terms/${termId}/groups/${groupId}/courses?includeRoles=PI`,
+    `/api/terms/${termId}/groups/${groupId}/courses`,
+    {
+      params: {
+        includeRoles: roles.length ? roles.join(",") : undefined,
+      },
+    },
   );
 
   return res.data;

--- a/resources/js/components/SelectGroup.vue
+++ b/resources/js/components/SelectGroup.vue
@@ -2,7 +2,7 @@
   <div class="form-group tw-mb-0">
     <label
       :for="selectId"
-      class="tw-uppercase tw-text-neutral-500 tw-font-bold tw-text-xs tw-tracking-wider tw-mb-1 tw-block"
+      class="tw-uppercase tw-text-neutral-500 tw-font-semibold tw-text-xs tw-tracking-wider tw-mb-2 tw-block"
       :class="[
         {
           'sr-only': !showLabel,

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -238,3 +238,8 @@ export type ApiGroupResponse = Group;
 export interface ApiUserLookupResponse {
   items: UserLookupItem[];
 }
+
+// used for api requests via Bandaid
+export type InstructorRole =
+  | "PI" // primary instuctor
+  | "TA"; // teaching assistant


### PR DESCRIPTION
![ScreenShot 2023-10-27 at 12 33 07@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/7f5284ca-40fd-4464-b3f2-e2a5d16b8e3f)

Adds a select to the Scheduling Report that lets users choose whether the generate the report for TA's or Primary Instructor's.

For testing: https://cla-groups-dev.oit.umn.edu/reports/schedulingReport/10

Details:
- The filters for report generation is getting complicated. This may work better as tabs, but I think I'll defer UI reorg until #71 is done.
- This contains no client side caching: changing from PI to TA and back will regenerate the report. If users are likely to do a lot of switching back and forth, LMK, and I can add some caching.
- I'm not sure about the labels. What language would users use when referring to "Instructor Role?"