### PR TITLE
permit all future terms to be plannable

### DIFF
--- a/resources/js/pages/CoursePlanningPage/components/EditDraftSectionModal.vue
+++ b/resources/js/pages/CoursePlanningPage/components/EditDraftSectionModal.vue
@@ -86,7 +86,11 @@ const emits = defineEmits<{
 const coursePlanningStore = useRootCoursePlanningStore();
 const isEditingSection = computed(() => !!props.initialCourse);
 
-const terms = computed(() => coursePlanningStore.scheduleableTerms);
+const terms = computed(() =>
+  coursePlanningStore.termsStore.terms.filter((t) =>
+    coursePlanningStore.termsStore.isTermPlannable(t.id),
+  ),
+);
 const courses = computed(() => coursePlanningStore.courseStore.allCourses);
 const people = computed(() => coursePlanningStore.personStore.allPeople);
 

--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTable.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTable.vue
@@ -9,9 +9,15 @@
       <colgroup>
         <col />
         <col
-          v-if="coursePlanningStore.isInPlanningMode"
-          class="term-col tw-bg-striped"
-          :span="coursePlanningStore.countOfTermsDisabledForPlanning"
+          v-for="term in coursePlanningStore.termsStore.terms"
+          v-show="coursePlanningStore.isTermVisible(term.id)"
+          :key="term.id"
+          class="term-col"
+          :class="{
+            'tw-bg-striped':
+              coursePlanningStore.isInPlanningMode &&
+              !coursePlanningStore.termsStore.isTermPlannable(term.id),
+          }"
         />
       </colgroup>
       <template #thead>

--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
@@ -10,14 +10,14 @@
     </LeaveChip>
 
     <Draggable
-      :disabled="!isEditable"
+      :disabled="!arePlannedSectionsEditable"
       :list="localCourseSections"
       group="sections"
       itemKey="id"
       ghostClass="ghost"
       class="tw-flex tw-flex-col tw-gap-2 tw-pb-12 tw-flex-1 tw-h-full group"
       :class="{
-        'tw-bg-neutral-50 tw-rounded tw-p-2': isEditable,
+        'tw-bg-neutral-50 tw-rounded tw-p-2': arePlannedSectionsEditable,
       }"
       @change="handeSectionChange"
     >
@@ -25,13 +25,13 @@
         <SectionDetails
           :section="section"
           :person="person"
-          :isEditable="isEditable"
-          :class="{ 'not-draggable': !isPlannable }"
+          :isEditable="arePlannedSectionsEditable"
+          :isViewable="arePlannedSectionsViewable"
         />
       </template>
       <template #footer>
         <button
-          v-if="isEditable"
+          v-if="arePlannedSectionsEditable"
           class="tw-bg-transparent tw-border-1 tw-border-dashed tw-border-black/10 tw-rounded tw-p-2 tw-text-sm tw-text-neutral-400 tw-transition-all tw-hidden group-hover:tw-flex tw-justify-center tw-items-center hover:tw-border-neutral-600 hover:tw-text-neutral-600 tw-leading-none"
           @click="isShowingAddCourse = true"
         >
@@ -101,26 +101,16 @@ const termLeavesForPerson = computed(() =>
     .filter((leave) => leave.termIds?.includes(props.term.id)),
 );
 
-const doesTermHavePublishedSections = computed(() => {
-  return (
-    coursePlanningStore.courseSectionStore
-      .getSectionsByTermId(props.term.id)
-      .filter((section) => section.isPublished).length > 0
-  );
-});
-
-const isPlannable = computed(() => {
-  return (
-    coursePlanningStore.isInPlanningMode && !doesTermHavePublishedSections.value
-  );
-});
-
-const isEditable = computed(() => {
+const arePlannedSectionsViewable = computed(() => {
   return (
     coursePlanningStore.isInPlanningMode &&
-    $can("edit planned courses") &&
-    !doesTermHavePublishedSections.value
+    coursePlanningStore.termsStore.isTermPlannable(props.term.id) &&
+    $can("view planned courses")
   );
+});
+
+const arePlannedSectionsEditable = computed(() => {
+  return arePlannedSectionsViewable.value && $can("edit planned courses");
 });
 
 const initialRole = computed(() => {

--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/SectionDetails.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/SectionDetails.vue
@@ -29,6 +29,7 @@ const props = defineProps<{
   section: T.CourseSection;
   person: T.Person;
   isEditable: boolean;
+  isViewable: boolean;
 }>();
 
 const planningStore = useRootCoursePlanningStore();
@@ -51,20 +52,5 @@ const enrollment = computed(() =>
     props.section,
   ),
 );
-
-const isViewable = computed(() => {
-  return (
-    planningStore.isSectionVisible(props.section) &&
-    enrollment.value &&
-    // show if published
-    (props.section.isPublished ||
-      // or if we're in planning mode and it's a draft section
-      (!props.section.isPublished && planningStore.isInPlanningMode)) &&
-    // and we're not filtering out this enrollment's role
-    planningStore.filters.includedEnrollmentRoles.includes(
-      enrollment.value.role,
-    )
-  );
-});
 </script>
 <style scoped></style>

--- a/resources/js/pages/CoursePlanningPage/stores/useRootCoursePlanningStore.ts
+++ b/resources/js/pages/CoursePlanningPage/stores/useRootCoursePlanningStore.ts
@@ -210,32 +210,6 @@ export const useRootCoursePlanningStore = defineStore(
       allCourseLevels: computed((): T.Course["courseLevel"][] =>
         Object.keys(getters.courseLevelCounts.value),
       ),
-      isTermSchedulable: computed(() => (termId: T.Term["id"]) => {
-        const termSections =
-          stores.courseSectionStore.getSectionsByTermId(termId);
-
-        if (!termSections) {
-          // if no sections found, then the term can be planned
-          return true;
-        }
-
-        // if there are sections, then make sure none
-        // are published
-        return !termSections.some((section) => section.isPublished);
-      }),
-      scheduleableTerms: computed((): T.Term[] => {
-        return stores.termsStore.sortedTerms.filter((term) =>
-          getters.isTermSchedulable.value(term.id),
-        );
-      }),
-
-      // for colspan
-      countOfTermsDisabledForPlanning: computed((): number => {
-        return getters.visibleTerms.value.filter((term) => {
-          return !getters.isTermSchedulable.value(term.id);
-        }).length;
-      }),
-
       isPersonVisible: computed(() => {
         if (!state.activeGroupId) {
           throw new Error("active group id is not set");

--- a/resources/js/stores/useTermsStore.ts
+++ b/resources/js/stores/useTermsStore.ts
@@ -59,6 +59,16 @@ export const useTermsStore = defineStore("terms", () => {
         value: term.id,
       })),
     ),
+
+    isTermPlannable: computed(() => (termId: T.Term["id"]): boolean => {
+      const term = getters.getTerm.value(termId);
+      if (!term)  {
+        throw new Error(`Cannot determine if term is plannable. Term ${termId} not found.`);
+      }
+      // terms that start within the next 2 months are no longer plannable
+      const lastPlannableDate = dayjs(term.startDate).subtract(2, "months");
+      return dayjs().isBefore(lastPlannableDate);
+    }),
   };
 
   const actions = {


### PR DESCRIPTION
This resolves an issue where depts may have some terms in the near future that still need planning. 

Previously, it was assumed that if any sections were scheduled in a given term, planning was complete for the given term AND previous terms.  However, this may not be the case. For example, a dept may have primary instructors assigned for Fall 2024, but may still be in planning stage for the previous term (Summer 2024).

This would cause the number of plannable terms to be miscalculated. (A related bug happens if a dept intentionally doesn't schedule any classes for a term).

Now, any term more than 2 months out will be plannable – even if it has some published sections.

![ScreenShot 2023-12-18 at 12 46 14@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/fb9da3f0-1737-4bbc-94bc-39e9d5723e46)
