### PR TITLE
Fix only course sections not showing up

### DIFF
--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
@@ -15,7 +15,7 @@
       group="sections"
       itemKey="id"
       ghostClass="ghost"
-      class="tw-flex tw-flex-col tw-gap-2 tw-pb-12 tw-flex-1 tw-h-full group"
+      class="tw-flex tw-flex-col tw-gap-1 tw-pb-12 tw-flex-1 tw-h-full group"
       :class="{
         'tw-bg-neutral-50 tw-rounded tw-p-2': arePlannedSectionsEditable,
       }"
@@ -25,8 +25,8 @@
         <SectionDetails
           :section="section"
           :person="person"
-          :isEditable="arePlannedSectionsEditable"
-          :isViewable="arePlannedSectionsViewable"
+          :isUnpublishedEditable="arePlannedSectionsEditable"
+          :isUnpublishedViewable="arePlannedSectionsViewable"
         />
       </template>
       <template #footer>

--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/SectionDetails.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/SectionDetails.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="course && enrollment && isViewable"
+    v-if="course && enrollment"
     :class="{
       'tw-bg-yellow-100': isSectionHighlighted,
     }"
@@ -11,8 +11,8 @@
       :course="course"
       :person="person"
       :enrollment="enrollment"
-      :isEditable="isEditable"
-      :isViewable="isViewable"
+      :isUnpublishedEditable="isUnpublishedEditable"
+      :isUnpublishedViewable="isUnpublishedViewable"
     />
 
     <PublishedSectionDetails v-else :section="section" :course="course" />
@@ -28,8 +28,8 @@ import UnpublishedSectionDetails from "./UnpublishedSectionDetails.vue";
 const props = defineProps<{
   section: T.CourseSection;
   person: T.Person;
-  isEditable: boolean;
-  isViewable: boolean;
+  isUnpublishedEditable: boolean;
+  isUnpublishedViewable: boolean;
 }>();
 
 const planningStore = useRootCoursePlanningStore();

--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/UnpublishedSectionDetails.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/UnpublishedSectionDetails.vue
@@ -51,8 +51,8 @@ const props = defineProps<{
   course: T.Course;
   person: T.Person;
   enrollment: T.Enrollment;
-  isEditable: boolean;
-  isViewable: boolean;
+  isUnpublishedEditable: boolean;
+  isUnpublishedViewable: boolean;
 }>();
 
 const planningStore = useRootCoursePlanningStore();

--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/UnpublishedSectionDetails.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/UnpublishedSectionDetails.vue
@@ -1,12 +1,13 @@
 <template>
   <div
+    v-if="isUnpublishedViewable"
     class="tw-bg-neutral-100 tw-py-2 tw-flex tw-gap-1 tw-items-top tw-italic tw-rounded"
     :class="{
-      'tw-cursor-move tw-shadow': isEditable,
-      'tw-cursor-default tw-px-2': !isEditable,
+      'tw-cursor-move tw-shadow': isUnpublishedEditable,
+      'tw-cursor-default tw-px-2': !isUnpublishedEditable,
     }"
   >
-    <DragHandleIcon v-if="isEditable" class="tw-inline-block" />
+    <DragHandleIcon v-if="isUnpublishedEditable" class="tw-inline-block" />
     <div class="tw-flex-1 tw-overflow-hidden">
       <h2 class="tw-text-sm tw-m-0">
         {{ course.subject }} {{ course.catalogNumber }}
@@ -15,7 +16,7 @@
         {{ course.title }}
       </p>
     </div>
-    <MoreMenu v-if="isEditable" class="tw-not-italic">
+    <MoreMenu v-if="isUnpublishedEditable" class="tw-not-italic">
       <MoreMenuItem
         class="tw-flex tw-gap-2 tw-items-center"
         @click="isShowingEditModal = true"
@@ -27,7 +28,6 @@
       </MoreMenuItem>
     </MoreMenu>
     <EditDraftSectionModal
-      v-if="isViewable"
       :show="isShowingEditModal"
       :initialPerson="person"
       :initialTerm="term"


### PR DESCRIPTION
This resolves an issue where some course sections were not showing up.

The issue was caused by a change in #83 for how `isViewable`  works. `isViewable` prop only pertains to unpublished sections, so the prop has been renamed as `isUnpublishedViewable`.

![ScreenShot 2023-12-18 at 16 32 20@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/4944eaaa-7cd7-4511-ae33-6de8d5018491)

Up on dev for testing