### PR TITLE
Add course planning functionality to Courses Tab on Leaves Scheduling Report

### DIFF
--- a/resources/js/components/DragDrop/DragDrop.vue
+++ b/resources/js/components/DragDrop/DragDrop.vue
@@ -32,7 +32,7 @@
   </div>
 </template>
 <script setup lang="ts" generic="ItemType extends { id: string | number; }">
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import { useDragDropStore } from "./useDragDropStore";
 import type { DragListItem, DragListId, DropEvent } from "@/types";
 
@@ -42,9 +42,13 @@ const props = withDefaults(
     group: string;
     list: ItemType[];
     disabled?: boolean;
+    // used to store arbitrary data about the list
+    // like the term id and course id for the course table
+    meta?: Record<string, unknown>;
   }>(),
   {
     disabled: false,
+    meta: undefined,
   },
 );
 
@@ -54,6 +58,14 @@ const emit = defineEmits<{
 
 const dragDropStore = useDragDropStore<ItemType>(props.group);
 const dragDropWrapperRef = ref<HTMLElement | null>(null);
+
+watch(
+  () => props.meta,
+  () => {
+    dragDropStore.setListMeta(props.id, props.meta);
+  },
+  { immediate: true },
+);
 
 const isItemBeingDragged = computed(() => (item: DragListItem) => {
   return dragDropStore.activeItem?.id === item.id;
@@ -134,6 +146,8 @@ function handleDrop() {
     item: dragDropStore.activeItem as ItemType,
     sourceListId: dragDropStore.sourceListId,
     targetListId: dragDropStore.targetListId,
+    sourceListMeta: dragDropStore.getListMeta(dragDropStore.sourceListId),
+    targetListMeta: dragDropStore.getListMeta(dragDropStore.targetListId),
   });
 }
 </script>

--- a/resources/js/components/DragDrop/DragDrop.vue
+++ b/resources/js/components/DragDrop/DragDrop.vue
@@ -31,10 +31,19 @@
     <slot name="footer" />
   </div>
 </template>
-<script setup lang="ts" generic="ItemType extends { id: string | number; }">
+<script
+  setup
+  lang="ts"
+  generic="ItemType extends { id: string | number; }, MetaType extends DragDropMeta = DragDropMeta"
+>
 import { ref, computed, watch } from "vue";
 import { useDragDropStore } from "./useDragDropStore";
-import type { DragListItem, DragListId, DropEvent } from "@/types";
+import type {
+  DragListItem,
+  DragListId,
+  DropEvent,
+  DragDropMeta,
+} from "@/types";
 
 const props = withDefaults(
   defineProps<{
@@ -44,7 +53,7 @@ const props = withDefaults(
     disabled?: boolean;
     // used to store arbitrary data about the list
     // like the term id and course id for the course table
-    meta?: Record<string, unknown>;
+    meta?: MetaType;
   }>(),
   {
     disabled: false,
@@ -53,7 +62,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (eventName: "drop", componentEvent: DropEvent<ItemType>): void;
+  (eventName: "drop", componentEvent: DropEvent<ItemType, MetaType>): void;
 }>();
 
 const dragDropStore = useDragDropStore<ItemType>(props.group);

--- a/resources/js/components/DragDrop/useDragDropStore.ts
+++ b/resources/js/components/DragDrop/useDragDropStore.ts
@@ -1,11 +1,11 @@
 import { computed, reactive, toRefs, UnwrapRef } from "vue";
 import { defineStore } from "pinia";
-import { DragListId } from "@/types";
+import { DragDropMeta, DragListId } from "@/types";
 interface DragDropState<ItemType> {
   activeItem: ItemType | null;
   sourceListId: DragListId | null;
   targetListId: DragListId | null;
-  listMeta: Record<DragListId, Record<string, unknown> | undefined>;
+  listMeta: Record<DragListId, DragDropMeta>;
 }
 
 const groupStores = new Map<string, ReturnType<typeof useDragDropStore>>();
@@ -30,11 +30,6 @@ export const useDragDropStore = <ItemType>(groupName: string) => {
       isDragging: computed((): boolean => {
         return state.activeItem !== null;
       }),
-      getListMeta: computed(
-        () =>
-          (listId: DragListId): Record<string, unknown> =>
-            state.listMeta[listId] ?? {},
-      ),
     };
 
     const actions = {
@@ -54,9 +49,11 @@ export const useDragDropStore = <ItemType>(groupName: string) => {
         state.sourceListId = null;
         state.targetListId = null;
       },
-      setListMeta(listId: DragListId, meta: Record<string, unknown>) {
+      setListMeta(listId: DragListId, meta: DragDropMeta) {
         state.listMeta[listId] = meta;
       },
+      getListMeta: (listId: DragListId): DragDropMeta =>
+        state.listMeta[listId] ?? {},
     };
 
     return {

--- a/resources/js/components/DragDrop/useDragDropStore.ts
+++ b/resources/js/components/DragDrop/useDragDropStore.ts
@@ -1,11 +1,11 @@
 import { computed, reactive, toRefs, UnwrapRef } from "vue";
 import { defineStore } from "pinia";
 import { DragListId } from "@/types";
-
 interface DragDropState<ItemType> {
   activeItem: ItemType | null;
   sourceListId: DragListId | null;
   targetListId: DragListId | null;
+  listMeta: Record<DragListId, Record<string, unknown> | undefined>;
 }
 
 const groupStores = new Map<string, ReturnType<typeof useDragDropStore>>();
@@ -23,12 +23,18 @@ export const useDragDropStore = <ItemType>(groupName: string) => {
       activeItem: null as ItemType | null,
       sourceListId: null as DragListId | null,
       targetListId: null as DragListId | null,
+      listMeta: {},
     });
 
     const getters = {
       isDragging: computed((): boolean => {
         return state.activeItem !== null;
       }),
+      getListMeta: computed(
+        () =>
+          (listId: DragListId): Record<string, unknown> =>
+            state.listMeta[listId] ?? {},
+      ),
     };
 
     const actions = {
@@ -47,6 +53,9 @@ export const useDragDropStore = <ItemType>(groupName: string) => {
         state.activeItem = null;
         state.sourceListId = null;
         state.targetListId = null;
+      },
+      setListMeta(listId: DragListId, meta: Record<string, unknown>) {
+        state.listMeta[listId] = meta;
       },
     };
 

--- a/resources/js/components/DraggableCard.vue
+++ b/resources/js/components/DraggableCard.vue
@@ -1,0 +1,46 @@
+<template>
+  <div
+    class="tw-bg-neutral-100 tw-py-2 tw-flex tw-gap-1 tw-items-top tw-italic tw-rounded"
+    :class="{
+      'tw-cursor-move tw-shadow': isDraggable,
+      'tw-cursor-default tw-px-2': !isDraggable,
+    }"
+  >
+    <DragHandleIcon v-if="isDraggable" class="tw-inline-block" />
+    <div class="tw-flex-1 tw-overflow-hidden">
+      <slot />
+    </div>
+    <MoreMenu v-if="isEditable" class="tw-not-italic">
+      <MoreMenuItem
+        class="tw-flex tw-gap-2 tw-items-center"
+        @click="$emit('click:edit')"
+      >
+        Edit
+      </MoreMenuItem>
+      <MoreMenuItem class="tw-text-red-600" @click="$emit('click:remove')">
+        Remove
+      </MoreMenuItem>
+    </MoreMenu>
+  </div>
+</template>
+<script setup lang="ts">
+import { DragHandleIcon } from "@/icons";
+import { MoreMenu, MoreMenuItem } from "@/components/MoreMenu";
+
+withDefaults(
+  defineProps<{
+    isDraggable?: boolean;
+    isEditable?: boolean;
+  }>(),
+  {
+    isDraggable: false,
+    isEditable: false,
+  },
+);
+
+defineEmits<{
+  (eventName: "click:edit"): void;
+  (eventName: "click:remove"): void;
+}>();
+</script>
+<style scoped></style>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTable.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTable.vue
@@ -1,5 +1,19 @@
 <template>
   <Table :stickyHeader="true" :stickyFirstColumn="true">
+    <colgroup>
+      <col />
+      <col
+        v-for="term in coursePlanningStore.termsStore.terms"
+        v-show="coursePlanningStore.isTermVisible(term.id)"
+        :key="term.id"
+        class="term-col"
+        :class="{
+          'tw-bg-striped':
+            coursePlanningStore.isInPlanningMode &&
+            !coursePlanningStore.termsStore.isTermPlannable(term.id),
+        }"
+      />
+    </colgroup>
     <THead>
       <ReportTableHeaderRow :label="`Courses`" />
     </THead>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTable.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTable.vue
@@ -1,5 +1,9 @@
 <template>
-  <Table :stickyHeader="true" :stickyFirstColumn="true">
+  <Table
+    :stickyHeader="true"
+    :stickyFirstColumn="true"
+    class="scheduling-report"
+  >
     <colgroup>
       <col />
       <col
@@ -44,7 +48,7 @@ defineProps<{
 const coursePlanningStore = useRootCoursePlanningStore();
 const courses = computed(() => coursePlanningStore.courseStore.allCourses);
 </script>
-<style scoped>
+<style scoped lang="scss">
 .term-data-column.term-data-column--current {
   background: #fffcf0;
   border-top: 1px solid #fde68a;
@@ -56,5 +60,13 @@ const courses = computed(() => coursePlanningStore.courseStore.allCourses);
 
 .term-data-column.term-data-column--fall {
   border-left: 2px solid #f3f3f3;
+}
+
+// fix width of cells to prevent them from embiggening
+// when a collapseable item is expanded
+.scheduling-report td,
+.scheduling-report th {
+  min-width: 16rem;
+  max-width: 16rem;
 }
 </style>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="tw-h-full">
     <EnrollmentInPublishedSection
       v-for="enrollment in enrollmentsInPublishedSection"
       :key="enrollment.id"
@@ -12,7 +12,7 @@
       group="course-table"
       :list="enrollmentsInUnpublishedSection"
       :disabled="!arePlannedSectionsEditable"
-      class="tw-flex tw-flex-col tw-gap-1 tw-pb-12 tw-flex-1 tw-h-full group"
+      class="tw-flex tw-flex-col tw-gap-1 tw-pb-12 tw-flex-1 tw-h-full tw-group"
       :meta="{
         course,
         term,
@@ -22,11 +22,29 @@
       <template #item="{ element: enrollment }">
         <EnrollmentInUnpublishedSection :enrollment="enrollment" />
       </template>
+      <template #footer>
+        <button
+          v-if="arePlannedSectionsEditable"
+          class="tw-bg-transparent tw-border-1 tw-border-dashed tw-border-black/10 tw-rounded tw-p-2 tw-text-sm tw-text-neutral-400 tw-transition-all tw-hidden group-hover:tw-flex tw-justify-center tw-items-center hover:tw-border-neutral-600 hover:tw-text-neutral-600 tw-leading-none"
+          @click="isShowingEditModal = true"
+        >
+          + Add Instructor
+        </button>
+      </template>
     </DragDrop>
+    <EditDraftSectionModal
+      v-if="isShowingEditModal"
+      :initialCourse="course"
+      :initialTerm="term"
+      initialRole="PI"
+      :show="isShowingEditModal"
+      @close="isShowingEditModal = false"
+      @save="coursePlanningStore.createSectionWithEnrollee"
+    />
   </div>
 </template>
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import * as T from "@/types";
 import { useRootCoursePlanningStore } from "../../stores/useRootCoursePlanningStore";
 import EnrollmentInPublishedSection from "./EnrollmentInPublishedSection.vue";
@@ -35,6 +53,7 @@ import { partition } from "lodash";
 import { DragDrop } from "@/components/DragDrop";
 import { $can } from "@/utils";
 import { DropEvent } from "@/types";
+import EditDraftSectionModal from "../EditDraftSectionModal.vue";
 
 const props = defineProps<{
   course: T.Course;
@@ -42,6 +61,7 @@ const props = defineProps<{
 }>();
 
 const coursePlanningStore = useRootCoursePlanningStore();
+const isShowingEditModal = ref(false);
 
 const enrollmentsInCourseByTermLookup = computed(
   (): Record<T.Term["id"], T.Enrollment[]> =>
@@ -135,4 +155,13 @@ async function handleEnrollmentChange(event: CourseTableDropEvent) {
   });
 }
 </script>
-<style scoped></style>
+<style scoped>
+.ghost {
+  opacity: 0.5;
+  background: #c8ebfb;
+}
+
+.not-draggable {
+  cursor: no-drop;
+}
+</style>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
@@ -40,7 +40,7 @@
       <span v-if="person.sslApplyEligible">✦ SSL Apply Eligible </span>
       <span v-if="person.sslEligible">✦ SSL Eligible</span>
       <span v-if="person.midcareerEligible">✦ Midcareer Eligible</span>
-      <span>Section {{}}</span>
+      <span>Section {{ section.classSection }}</span>
     </div>
   </div>
 </template>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
@@ -7,6 +7,7 @@
     />
 
     <DragDrop
+      v-if="arePlannedSectionsViewable"
       :id="`courseid.${course.id}_termid.${term.id}`"
       group="course-table"
       :list="enrollmentsInUnpublishedSection"

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
@@ -6,22 +6,30 @@
       :enrollment="enrollment"
     />
 
-    <EnrollmentInUnpublishedSection
-      v-for="enrollment in enrollmentsInUnpublishedSection"
-      :key="enrollment.id"
-      :enrollment="enrollment"
-    />
+    <DragDrop
+      :id="`courseid.${course.id}-termid.${term.id}`"
+      group="course-table"
+      :list="enrollmentsInUnpublishedSection"
+      :disabled="!arePlannedSectionsEditable"
+      class="tw-flex tw-flex-col tw-gap-1 tw-pb-12 tw-flex-1 tw-h-full group"
+      @drop="handleEnrollmentChange"
+    >
+      <template #item="{ element: enrollment }">
+        <EnrollmentInUnpublishedSection :enrollment="enrollment" />
+      </template>
+    </DragDrop>
   </div>
 </template>
 <script setup lang="ts">
-import { ref, computed } from "vue";
-import ChevronDownIcon from "@/icons/ChevronDownIcon.vue";
+import { computed } from "vue";
 import * as T from "@/types";
 import { useRootCoursePlanningStore } from "../../stores/useRootCoursePlanningStore";
-import { ChevronRightIcon } from "@/icons";
 import EnrollmentInPublishedSection from "./EnrollmentInPublishedSection.vue";
 import EnrollmentInUnpublishedSection from "./EnrollmentInUnpublishedSection.vue";
 import { partition } from "lodash";
+import { DragDrop } from "@/components/DragDrop";
+import { $can } from "@/utils";
+import { DropEvent } from "@/types";
 
 const props = defineProps<{
   course: T.Course;
@@ -55,5 +63,32 @@ const enrollmentsInPublishedSection = computed(() => {
 const enrollmentsInUnpublishedSection = computed(() => {
   return partitionedEnrollments.value[1];
 });
+
+const arePlannedSectionsViewable = computed(() => {
+  return (
+    coursePlanningStore.isInPlanningMode &&
+    coursePlanningStore.termsStore.isTermPlannable(props.term.id) &&
+    $can("view planned courses")
+  );
+});
+
+const arePlannedSectionsEditable = computed(() => {
+  return arePlannedSectionsViewable.value && $can("edit planned courses");
+});
+
+// function getPreviousCourseFromEvent(
+//   event: DropEvent<T.Enrollment>,
+// ): T.Course | null {
+//   // use the source list id to get the person id
+//   const courseInfo = (event.sourceListId as string).split("-")[0];
+//   const courseId = courseInfo.split(".")[1] as T.Course["id"];
+
+//   // then use the person id to get the person
+//   return coursePlanningStore.courseStore.getCourse(courseId);
+// }
+
+async function handleEnrollmentChange(event: DropEvent<T.Enrollment>) {
+  console.log("handleEnrollmentChange", event);
+}
 </script>
 <style scoped></style>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCell.vue
@@ -7,11 +7,15 @@
     />
 
     <DragDrop
-      :id="`courseid.${course.id}-termid.${term.id}`"
+      :id="`courseid.${course.id}_termid.${term.id}`"
       group="course-table"
       :list="enrollmentsInUnpublishedSection"
       :disabled="!arePlannedSectionsEditable"
       class="tw-flex tw-flex-col tw-gap-1 tw-pb-12 tw-flex-1 tw-h-full group"
+      :meta="{
+        course,
+        term,
+      }"
       @drop="handleEnrollmentChange"
     >
       <template #item="{ element: enrollment }">
@@ -87,7 +91,14 @@ const arePlannedSectionsEditable = computed(() => {
 //   return coursePlanningStore.courseStore.getCourse(courseId);
 // }
 
-async function handleEnrollmentChange(event: DropEvent<T.Enrollment>) {
+interface CourseTableDragDropMeta extends T.DragDropMeta {
+  course: T.Course;
+  term: T.Term;
+}
+
+type CourseTableDropEvent = DropEvent<T.Enrollment, CourseTableDragDropMeta>;
+
+async function handleEnrollmentChange(event: CourseTableDropEvent) {
   console.log("handleEnrollmentChange", event);
 }
 </script>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCourseRow.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCourseRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <tr v-if="isCourseVisible">
+  <tr v-if="isCourseVisible" class="course-table-row">
     <Td class="course-column">
       <div
         :class="{
@@ -63,8 +63,12 @@ const isCourseHighlighted = computed(() => {
 });
 </script>
 <style scoped>
+.term-data-column {
+  border-left: 1px solid #f3f3f3;
+}
+
 .term-data-column.term-data-column--current {
-  background: #fffcf0;
+  background: rgb(255 248 220 / 68%);
   border-top: 1px solid #fde68a;
 }
 
@@ -74,5 +78,8 @@ const isCourseHighlighted = computed(() => {
 
 .term-data-column.term-data-column--fall {
   border-left: 2px solid #f3f3f3;
+}
+.course-table-row:hover .instructor-column {
+  background-color: #f3f3f3;
 }
 </style>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCourseRow.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCourseRow.vue
@@ -24,17 +24,12 @@
         'term-data-column--fall': term.name.includes('Fall'),
       }"
     >
-      <CourseTableCell
-        v-for="enrollment in getEnrollmentsForTerm(term)"
-        :key="enrollment.id"
-        :enrollment="enrollment"
-      />
+      <CourseTableCell :course="course" :term="term" />
     </Td>
   </tr>
 </template>
 <script setup lang="ts">
 import { Td } from "@/components/Table";
-import { Term } from "@/types";
 import CourseTableCell from "./CourseTableCell.vue";
 import { useRootCoursePlanningStore } from "../../stores/useRootCoursePlanningStore";
 import * as T from "@/types";
@@ -47,14 +42,14 @@ const props = defineProps<{
 const coursePlanningStore = useRootCoursePlanningStore();
 const visibleTerms = computed(() => coursePlanningStore.visibleTerms);
 
-const enrollmentsByTermLookup = computed(
-  (): Record<Term["id"], T.Enrollment[]> =>
-    coursePlanningStore.getEnrollmentsInCourseByTerm(props.course.id),
-);
+// const enrollmentsByTermLookup = computed(
+//   (): Record<Term["id"], T.Enrollment[]> =>
+//     coursePlanningStore.getEnrollmentsInCourseByTerm(props.course.id),
+// );
 
-function getEnrollmentsForTerm(term: Term): T.Enrollment[] {
-  return enrollmentsByTermLookup.value[term.id] ?? [];
-}
+// function getEnrollmentsForTerm(term: Term): T.Enrollment[] {
+//   return enrollmentsByTermLookup.value[term.id] ?? [];
+// }
 
 const isCourseVisible = computed(() => {
   return coursePlanningStore.isCourseVisible(props.course);

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCourseRow.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/CourseTableCourseRow.vue
@@ -24,7 +24,7 @@
         'term-data-column--fall': term.name.includes('Fall'),
       }"
     >
-      <EnrollmentDetails
+      <CourseTableCell
         v-for="enrollment in getEnrollmentsForTerm(term)"
         :key="enrollment.id"
         :enrollment="enrollment"
@@ -35,7 +35,7 @@
 <script setup lang="ts">
 import { Td } from "@/components/Table";
 import { Term } from "@/types";
-import EnrollmentDetails from "./EnrollmentDetails.vue";
+import CourseTableCell from "./CourseTableCell.vue";
 import { useRootCoursePlanningStore } from "../../stores/useRootCoursePlanningStore";
 import * as T from "@/types";
 import { computed } from "vue";

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInPublishedSection.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInPublishedSection.vue
@@ -15,8 +15,8 @@
         @click="isOpen = !isOpen"
       >
         <span class="tw-sr-only">Show More</span>
-        <ChevronDownIcon v-if="isOpen" />
-        <ChevronRightIcon v-else />
+        <ChevronDownIcon v-if="isOpen" class="!tw-w-4 !tw-h-4" />
+        <ChevronRightIcon v-else class="!tw-w-4 !tw-h-4" />
       </button>
       <div>
         <RouterLink :to="`/user/${person.id}`">

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInPublishedSection.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInPublishedSection.vue
@@ -1,0 +1,86 @@
+<template>
+  <div
+    v-if="isEnrollmentVisible && person && section"
+    class="instructor-details tw-truncate"
+    :class="{
+      'tw-opacity-50 tw-line-through': section.isCancelled,
+      'tw-bg-yellow-100': isPersonHighlighted,
+      'tw-rounded-md tw-bg-black/5 tw-p-2 tw-pr-4 tw-mb-2': isOpen,
+      'tw-rounded-full': !isOpen,
+    }"
+  >
+    <div class="tw-flex tw-items-center tw-gap-1">
+      <button
+        class="tw-border-none tw-bg-transparent tw-text-neutral-500 tw-rounded-full tw-p-1 tw-flex tw-items-center tw-justify-center"
+        @click="isOpen = !isOpen"
+      >
+        <span class="tw-sr-only">Show More</span>
+        <ChevronDownIcon v-if="isOpen" />
+        <ChevronRightIcon v-else />
+      </button>
+      <div>
+        <RouterLink :to="`/user/${person.id}`">
+          {{ person.surName }}, {{ person.givenName }}
+        </RouterLink>
+        <span class="tw-text-xs tw-text-neutral-500 tw-ml-1">
+          {{ section.enrollmentTotal }}/{{ section.enrollmentCap }}
+        </span>
+      </div>
+    </div>
+
+    <div
+      v-show="isOpen"
+      class="tw-text-xs tw-text-neutral-500 tw-flex tw-flex-col tw-pl-7 tw-gap-1"
+    >
+      <span>
+        {{ person.title }}
+        {{ person.jobCode ? `(${person.jobCode})` : "" }}
+      </span>
+      <span>{{ person.emplid }}</span>
+      <span v-if="person.sslApplyEligible">✦ SSL Apply Eligible </span>
+      <span v-if="person.sslEligible">✦ SSL Eligible</span>
+      <span v-if="person.midcareerEligible">✦ Midcareer Eligible</span>
+      <span>Section {{ section.classSection }}</span>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import ChevronDownIcon from "@/icons/ChevronDownIcon.vue";
+import * as T from "@/types";
+import { useRootCoursePlanningStore } from "../../stores/useRootCoursePlanningStore";
+import { ChevronRightIcon } from "@/icons";
+
+const props = defineProps<{
+  enrollment: T.Enrollment;
+}>();
+
+const coursePlanningStore = useRootCoursePlanningStore();
+const isOpen = ref(false);
+
+const person = computed((): T.Person | null =>
+  coursePlanningStore.personStore.getPersonByEmplId(props.enrollment.emplid),
+);
+
+const section = computed((): T.CourseSection | null =>
+  coursePlanningStore.courseSectionStore.getSection(props.enrollment.sectionId),
+);
+
+const isEnrollmentVisible = computed(() => {
+  if (!person.value || !section.value) {
+    return false;
+  }
+  return (
+    coursePlanningStore.isPersonVisible(person.value.emplid) &&
+    coursePlanningStore.isSectionVisible(section.value)
+  );
+});
+
+const isPersonHighlighted = computed(
+  () =>
+    coursePlanningStore.filters.search.length &&
+    person.value &&
+    coursePlanningStore.isPersonMatchingSearch(person.value),
+);
+</script>
+<style scoped></style>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInUnpublishedSection.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInUnpublishedSection.vue
@@ -1,26 +1,138 @@
 <template>
   <div>
-    <p>{{ person?.emplid }}</p>
-    <p>{{ section?.dbId }}</p>
+    <DraggableCard
+      v-if="isUnpublishedViewable"
+      :isDraggable="isUnpublishedEditable"
+      :isEditable="isUnpublishedEditable"
+      @click:remove="handleRemove"
+      @click:edit="isShowingEditModal = true"
+    >
+      <h2 class="tw-text-sm tw-m-0">
+        {{ person?.givenName }} {{ person?.surName ?? "Unknown" }}
+      </h2>
+      <p class="tw-text-xs tw-m-0">{{ person?.emplid }}</p>
+
+      <p class="tw-text-xs tw-m-0">
+        {{ prettyEnrollmentRole }}
+      </p>
+    </DraggableCard>
+    <EditDraftSectionModal
+      :show="isShowingEditModal"
+      :initialPerson="person"
+      :initialTerm="term"
+      :initialCourse="course"
+      :initialRole="enrollment.role"
+      @save="handleEditSave"
+      @close="isShowingEditModal = false"
+    />
   </div>
 </template>
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, h, ref } from "vue";
 import * as T from "@/types";
 import { useRootCoursePlanningStore } from "../../stores/useRootCoursePlanningStore";
+import DraggableCard from "@/components/DraggableCard.vue";
+import { capitalize } from "lodash";
+import { $can } from "@/utils";
+import EditDraftSectionModal from "../EditDraftSectionModal.vue";
 
 const props = defineProps<{
   enrollment: T.Enrollment;
 }>();
 
-const coursePlanningStore = useRootCoursePlanningStore();
+const planningStore = useRootCoursePlanningStore();
 
 const person = computed((): T.Person | null =>
-  coursePlanningStore.personStore.getPersonByEmplId(props.enrollment.emplid),
+  planningStore.personStore.getPersonByEmplId(props.enrollment.emplid),
+);
+
+const prettyEnrollmentRole = computed(() =>
+  T.enrollmentRoleMap[props.enrollment.role]
+    .split(" ")
+    .map(capitalize)
+    .join(" "),
 );
 
 const section = computed((): T.CourseSection | null =>
-  coursePlanningStore.courseSectionStore.getSection(props.enrollment.sectionId),
+  planningStore.courseSectionStore.getSection(props.enrollment.sectionId),
 );
+
+const term = computed(() =>
+  section.value ? planningStore.termsStore.getTerm(section.value.termId) : null,
+);
+const course = computed(() =>
+  section.value
+    ? planningStore.courseStore.getCourse(section.value.courseId)
+    : null,
+);
+
+const isUnpublishedViewable = computed((): boolean => {
+  return (
+    !!section.value &&
+    planningStore.isInPlanningMode &&
+    planningStore.termsStore.isTermPlannable(section.value.termId) &&
+    $can("view planned courses")
+  );
+});
+
+const isUnpublishedEditable = computed((): boolean => {
+  return isUnpublishedViewable.value && $can("edit planned courses");
+});
+
+const isShowingEditModal = ref(false);
+
+function handleEditSave({
+  course,
+  term,
+  person,
+  role,
+}: {
+  course: T.Course;
+  term: T.Term;
+  person: T.Person;
+  role: T.EnrollmentRole;
+}) {
+  if (!section.value) {
+    throw new Error("No section found for enrollment");
+  }
+
+  const hasSectionChanged =
+    course.id !== section.value.courseId || term.id !== section.value.termId;
+
+  if (hasSectionChanged) {
+    const updatedSection: T.CourseSection = {
+      ...section.value,
+      courseId: course.id,
+      termId: term.id,
+      isPublished: false,
+    };
+
+    planningStore.courseSectionStore.updateSection(updatedSection);
+  }
+
+  if (!props.enrollment) {
+    throw new Error("No enrollment found for section");
+  }
+
+  const hasEnrollmentChanged =
+    props.enrollment.emplid !== person.emplid || props.enrollment.role !== role;
+  if (hasEnrollmentChanged) {
+    const updatedEnrollment: T.Enrollment = {
+      ...props.enrollment,
+      emplid: person.emplid,
+      role,
+    };
+    planningStore.enrollmentStore.updateEnrollment(updatedEnrollment);
+  }
+}
+
+function handleRemove() {
+  if (!section.value) {
+    throw new Error("No section found for enrollment");
+  }
+
+  planningStore.courseSectionStore.removeSection(section.value);
+  planningStore.enrollmentStore.removeEnrollment(props.enrollment);
+}
 </script>
 <style scoped></style>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInUnpublishedSection.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInUnpublishedSection.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <p>{{ person?.emplid }}</p>
+    <p>{{ section?.dbId }}</p>
+  </div>
+</template>
+<script setup lang="ts">
+import { computed } from "vue";
+import * as T from "@/types";
+import { useRootCoursePlanningStore } from "../../stores/useRootCoursePlanningStore";
+
+const props = defineProps<{
+  enrollment: T.Enrollment;
+}>();
+
+const coursePlanningStore = useRootCoursePlanningStore();
+
+const person = computed((): T.Person | null =>
+  coursePlanningStore.personStore.getPersonByEmplId(props.enrollment.emplid),
+);
+
+const section = computed((): T.CourseSection | null =>
+  coursePlanningStore.courseSectionStore.getSection(props.enrollment.sectionId),
+);
+</script>
+<style scoped></style>

--- a/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInUnpublishedSection.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CourseTable/EnrollmentInUnpublishedSection.vue
@@ -10,7 +10,6 @@
       <h2 class="tw-text-sm tw-m-0">
         {{ person?.givenName }} {{ person?.surName ?? "Unknown" }}
       </h2>
-      <p class="tw-text-xs tw-m-0">{{ person?.emplid }}</p>
 
       <p class="tw-text-xs tw-m-0">
         {{ prettyEnrollmentRole }}
@@ -28,11 +27,10 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed, h, ref } from "vue";
+import { computed, ref } from "vue";
 import * as T from "@/types";
 import { useRootCoursePlanningStore } from "../../stores/useRootCoursePlanningStore";
 import DraggableCard from "@/components/DraggableCard.vue";
-import { capitalize } from "lodash";
 import { $can } from "@/utils";
 import EditDraftSectionModal from "../EditDraftSectionModal.vue";
 
@@ -46,11 +44,8 @@ const person = computed((): T.Person | null =>
   planningStore.personStore.getPersonByEmplId(props.enrollment.emplid),
 );
 
-const prettyEnrollmentRole = computed(() =>
-  T.enrollmentRoleMap[props.enrollment.role]
-    .split(" ")
-    .map(capitalize)
-    .join(" "),
+const prettyEnrollmentRole = computed(
+  () => T.enrollmentRoleMap[props.enrollment.role],
 );
 
 const section = computed((): T.CourseSection | null =>

--- a/resources/js/pages/CoursePlanningPage/components/EditDraftSectionModal.vue
+++ b/resources/js/pages/CoursePlanningPage/components/EditDraftSectionModal.vue
@@ -64,10 +64,10 @@ import * as T from "@/types";
 
 const props = defineProps<{
   show: boolean;
-  initialPerson?: T.Person;
+  initialPerson?: T.Person | null;
   initialTerm?: Term | null;
-  initialCourse?: T.Course;
-  initialRole?: T.EnrollmentRole;
+  initialCourse?: T.Course | null;
+  initialRole?: T.EnrollmentRole | null;
 }>();
 
 const emits = defineEmits<{

--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
@@ -22,6 +22,7 @@
       :list="unpublishedSections"
       :disabled="!arePlannedSectionsEditable"
       class="tw-flex tw-flex-col tw-gap-1 tw-pb-12 tw-flex-1 tw-h-full group"
+      :meta="{ person, term }"
       @drop="handleSectionChange"
     >
       <template #item="{ element: section }">
@@ -123,19 +124,20 @@ function handleSaveTentativeCourse({ term, course, person, role }) {
   });
 }
 
-function getPreviousPersonFromEvent(
-  event: DropEvent<T.CourseSection>,
-): T.Person | null {
-  // use the source list id to get the person id
-  const personInfo = (event.sourceListId as string).split("-")[0];
-  const personEmplidStr = personInfo.split(".")[1];
-  const personEmplid = Number.parseInt(personEmplidStr);
-
-  // then use the person id to get the person
-  return coursePlanningStore.personStore.getPersonByEmplId(personEmplid);
+interface PersonTableDragDropMeta extends T.DragDropMeta {
+  person: T.Person;
+  term: T.Term;
 }
 
-async function handleSectionChange(event: DropEvent<T.CourseSection>) {
+type PersonTableDropEvent = DropEvent<T.CourseSection, PersonTableDragDropMeta>;
+
+function getPreviousPersonFromEvent(
+  event: PersonTableDropEvent,
+): T.Person | null {
+  return event.sourceListMeta.person as T.Person | null;
+}
+
+async function handleSectionChange(event: PersonTableDropEvent) {
   const previousSection = event.item;
   const previousPerson = getPreviousPersonFromEvent(event);
 

--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
@@ -22,7 +22,7 @@
       group="person-table"
       :list="unpublishedSections"
       :disabled="!arePlannedSectionsEditable"
-      class="tw-flex tw-flex-col tw-gap-1 tw-pb-12 tw-flex-1 tw-h-full group"
+      class="tw-flex tw-flex-col tw-gap-1 tw-pb-12 tw-flex-1 tw-h-full tw-group"
       :meta="{ person, term }"
       @drop="handleSectionChange"
     >
@@ -33,7 +33,7 @@
         <button
           v-if="arePlannedSectionsEditable"
           class="tw-bg-transparent tw-border-1 tw-border-dashed tw-border-black/10 tw-rounded tw-p-2 tw-text-sm tw-text-neutral-400 tw-transition-all tw-hidden group-hover:tw-flex tw-justify-center tw-items-center hover:tw-border-neutral-600 hover:tw-text-neutral-600 tw-leading-none"
-          @click="isShowingAddCourse = true"
+          @click="isShowingEditModal = true"
         >
           + Add Course
         </button>
@@ -41,13 +41,13 @@
     </DragDrop>
 
     <EditDraftSectionModal
-      v-if="isShowingAddCourse"
+      v-if="isShowingEditModal"
       :initialPerson="person"
       :initialTerm="term"
       :initialRole="initialRole"
-      :show="isShowingAddCourse"
-      @close="isShowingAddCourse = false"
-      @save="handleSaveTentativeCourse"
+      :show="isShowingEditModal"
+      @close="isShowingEditModal = false"
+      @save="coursePlanningStore.createSectionWithEnrollee"
     />
   </div>
 </template>
@@ -85,7 +85,7 @@ const unpublishedSections = computed(() => {
   return courseSections.value.filter((section) => !section.isPublished);
 });
 
-const isShowingAddCourse = ref(false);
+const isShowingEditModal = ref(false);
 
 const termLeavesForPerson = computed(() =>
   coursePlanningStore.leaveStore
@@ -115,15 +115,6 @@ const initialRole = computed(() => {
   // otherwise, default to Primary Instructor
   return "PI";
 });
-
-function handleSaveTentativeCourse({ term, course, person, role }) {
-  coursePlanningStore.createSectionWithEnrollee({
-    course,
-    term,
-    person,
-    role,
-  });
-}
 
 interface PersonTableDragDropMeta extends T.DragDropMeta {
   person: T.Person;

--- a/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
+++ b/resources/js/pages/CoursePlanningPage/components/PersonTable/PersonTableCell.vue
@@ -17,6 +17,7 @@
     />
 
     <DragDrop
+      v-if="arePlannedSectionsViewable"
       :id="`emplid.${person.emplid}-termid.${term.id}`"
       group="person-table"
       :list="unpublishedSections"

--- a/resources/js/pages/CoursePlanningPage/stores/useCourseSectionStore.ts
+++ b/resources/js/pages/CoursePlanningPage/stores/useCourseSectionStore.ts
@@ -53,6 +53,24 @@ export const useCourseSectionStore = defineStore("couseSection", () => {
           return state.sectionLookup[sectionId] ?? null;
         },
     ),
+    getSectionWithEnrollments: computed(
+      () =>
+        (
+          sectionId: T.CourseSection["id"],
+        ): T.CourseSectionWithEnrollments | null => {
+          const section = getters.getSection.value(sectionId);
+          if (!section) {
+            return null;
+          }
+          const enrollmentStore = useEnrollmentStore();
+          const enrollments =
+            enrollmentStore.getEnrollmentsBySectionId(sectionId);
+          return {
+            ...section,
+            enrollments,
+          };
+        },
+    ),
   };
 
   const actions = {

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -290,6 +290,10 @@ export interface CourseSection {
   isPublished: boolean; // true if from bandaid, false if from app DB
 }
 
+export interface CourseSectionWithEnrollments extends CourseSection {
+  enrollments: Enrollment[];
+}
+
 type CourseShortCode = `${Course["subject"]}-${Course["catalogNumber"]}`;
 
 export interface Course {

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -224,8 +224,8 @@ export interface Term {
 export type TermCode = "FA" | "SP" | "SU";
 
 export const enrollmentRoleMap = {
-  PI: "primary instructor",
-  TA: "teaching assistant",
+  PI: "Primary Instructor",
+  TA: "Teaching Assistant",
 } as const;
 
 export type EnrollmentRole = keyof typeof enrollmentRoleMap;
@@ -340,10 +340,17 @@ export interface SelectOption {
   value: string | number;
 }
 
-export interface DropEvent<U> {
-  item: U;
+export type DragDropMeta = Record<string, unknown>;
+
+export interface DropEvent<
+  ItemType,
+  MetaDataType extends DragDropMeta = DragDropMeta,
+> {
+  item: ItemType;
   sourceListId: DragListId;
   targetListId: DragListId;
+  sourceListMeta: MetaDataType;
+  targetListMeta: MetaDataType;
 }
 
 export interface DragListItem {

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -228,8 +228,7 @@ export const enrollmentRoleMap = {
   TA: "teaching assistant",
 } as const;
 
-export type EnrollmentRole =
-  (typeof enrollmentRoleMap)[keyof typeof enrollmentRoleMap];
+export type EnrollmentRole = keyof typeof enrollmentRoleMap;
 
 export interface Person {
   id: number;

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -223,7 +223,13 @@ export interface Term {
 
 export type TermCode = "FA" | "SP" | "SU";
 
-export type EnrollmentRole = "PI" | "TA";
+export const enrollmentRoleMap = {
+  PI: "primary instructor",
+  TA: "teaching assistant",
+} as const;
+
+export type EnrollmentRole =
+  (typeof enrollmentRoleMap)[keyof typeof enrollmentRoleMap];
 
 export interface Person {
   id: number;
@@ -322,9 +328,7 @@ export interface ApiUserLookupResponse {
 }
 
 // used for api requests via Bandaid
-export type InstructorRole =
-  | "PI" // primary instuctor
-  | "TA"; // teaching assistant
+export type InstructorRole = EnrollmentRole;
 
 export type LoadState = "idle" | "loading" | "complete" | "error";
 

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -224,7 +224,7 @@ export interface Term {
 export type TermCode = "FA" | "SP" | "SU";
 
 export const enrollmentRoleMap = {
-  PI: "Primary Instructor",
+  PI: "Instructor", // Primary Instructor
   TA: "Teaching Assistant",
 } as const;
 


### PR DESCRIPTION
![ScreenShot 2024-01-30 at 15 35 02](https://github.com/UMN-LATIS/bluesheet/assets/980170/3b134b16-e529-42c3-b66b-415f6910f3d8)

Previously, users could plan future course sections from the Instructors and Teaching Assistants tab. This adds similar functionality to the Courses tab.

On https://cla-groups-dev.oit.umn.edu/course-planning/groups/23 for testing.

Closes #90 