### PR TITLE
Fix sorting on Group page and some reports

### DIFF
--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -276,6 +276,7 @@ import Modal from "./Modal.vue";
 import { dayjs, $can } from "@/utils";
 import { PropType } from "vue";
 import { Group, MemberRole, Membership } from "@/types";
+import { get as getValueAtPath } from "lodash";
 
 type SortableField =
   | "user.surname"
@@ -436,11 +437,12 @@ export default defineComponent({
     },
     sortedList() {
       return [...this.compositeList].sort((a, b) => {
-        let modifier = 1;
-        if (this.currentSortDir === "desc") modifier = -1;
+        const modifier = this.currentSortDir === "desc" ? -1 : 1;
 
-        const aCurrentSort = a?.[this.currentSort] || " ";
-        const bCurrentSort = b?.[this.currentSort] || " ";
+        // this.currentSort is a path to a field on the membership object
+        // e.g. "user.surname". Use `get` from lodash to get the value
+        const aCurrentSort = getValueAtPath(a, this.currentSort) || " ";
+        const bCurrentSort = getValueAtPath(b, this.currentSort) || " ";
 
         if (aCurrentSort < bCurrentSort) return -1 * modifier;
         if (aCurrentSort > bCurrentSort) return 1 * modifier;

--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -276,7 +276,7 @@ import Modal from "./Modal.vue";
 import { dayjs, $can } from "@/utils";
 import { PropType } from "vue";
 import { Group, MemberRole, Membership } from "@/types";
-import { get as getValueAtPath } from "lodash";
+import { sortByValueAtPath } from "@/utils";
 
 type SortableField =
   | "user.surname"
@@ -436,18 +436,9 @@ export default defineComponent({
       return this.members.concat(childMembers).filter(Boolean);
     },
     sortedList() {
-      return [...this.compositeList].sort((a, b) => {
-        const modifier = this.currentSortDir === "desc" ? -1 : 1;
-
-        // this.currentSort is a path to a field on the membership object
-        // e.g. "user.surname". Use `get` from lodash to get the value
-        const aCurrentSort = getValueAtPath(a, this.currentSort) || " ";
-        const bCurrentSort = getValueAtPath(b, this.currentSort) || " ";
-
-        if (aCurrentSort < bCurrentSort) return -1 * modifier;
-        if (aCurrentSort > bCurrentSort) return 1 * modifier;
-        return 0;
-      });
+      return [...this.compositeList].sort(
+        sortByValueAtPath(this.currentSort, this.currentSortDir),
+      );
     },
     emailList() {
       let targetList = this.filteredList;

--- a/resources/js/components/SortableLink.vue
+++ b/resources/js/components/SortableLink.vue
@@ -4,20 +4,33 @@
     <i
       class="fas"
       :class="{
-        'fa-sort-alpha-up':
-          currentSortDir == 'desc' && currentSort == sortElement,
-        'fa-sort-alpha-down':
-          currentSortDir == 'asc' && currentSort == sortElement,
+        'fa-sort-alpha-up': currentSortDir == 'desc' && isCurrentSort,
+        'fa-sort-alpha-down': currentSortDir == 'asc' && isCurrentSort,
       }"
     ></i>
   </span>
 </template>
 
-<script>
-export default {
-  props: ["sortLabel", "sortElement", "currentSort", "currentSortDir"],
-  emits: ["sort"],
-};
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+  sortLabel: string;
+  // this sort element name
+  sortElement: string;
+  // the current sort element for a given table
+  currentSort: string;
+
+  currentSortDir: "asc" | "desc";
+}>();
+
+defineEmits<{
+  (eventName: "sort", value: string): void;
+}>();
+
+const isCurrentSort = computed(() => {
+  return props.currentSort === props.sortElement;
+});
 </script>
 
 <style>

--- a/resources/js/components/ViewGroup.vue
+++ b/resources/js/components/ViewGroup.vue
@@ -103,10 +103,10 @@
       :members="group.members"
       :group="group"
       :editing="false"
-      :show_unit="group.show_unit"
+      :show_unit="Boolean(group.show_unit)"
       :roles="rolesRelatedToGroup"
       viewType="group"
-      :downloadTitle="group.group_title"
+      :downloadTitle="group.group_title ?? 'Unnamed Group'"
     ></Members>
 
     <router-link

--- a/resources/js/pages/reports/EligibilityReport.vue
+++ b/resources/js/pages/reports/EligibilityReport.vue
@@ -87,7 +87,7 @@
 <script>
 import SortableLink from "@/components/SortableLink.vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
-import { axios } from "@/utils";
+import { axios, sortByValueAtPath } from "@/utils";
 import DownloadCSV from "@/components/DownloadCSV.vue";
 import { $can } from "@/utils";
 
@@ -117,19 +117,9 @@ export default {
       });
     },
     sortedList: function () {
-      return [...this.userList].sort((a, b) => {
-        let modifier = 1;
-        if (this.currentSortDir === "desc") modifier = -1;
-
-        const aCurrentSort = a?.[this.currentSort] || " ";
-        const bCurrentSort = b?.[this.currentSort] || " ";
-
-        if (aCurrentSort.toLowerCase() < bCurrentSort.toLowerCase())
-          return -1 * modifier;
-        if (aCurrentSort.toLowerCase() > bCurrentSort.toLowerCase())
-          return 1 * modifier;
-        return 0;
-      });
+      return [...this.userList].sort(
+        sortByValueAtPath(this.currentSort, this.currentSortDir),
+      );
     },
   },
   watch: {

--- a/resources/js/pages/reports/FiscalReportPage.vue
+++ b/resources/js/pages/reports/FiscalReportPage.vue
@@ -54,7 +54,7 @@
           <th>
             <SortableLink
               sortLabel="Accountant"
-              sortElement="accountant"
+              sortElement="accountant.0.user.displayName"
               :currentSort="currentSort"
               :currentSortDir="currentSortDir"
               @sort="sort"
@@ -63,7 +63,7 @@
           <th>
             <SortableLink
               sortLabel="Finance Manager"
-              sortElement="financeManager"
+              sortElement="financeManager.0.user.displayName"
               :currentSort="currentSort"
               :currentSortDir="currentSortDir"
               @sort="sort"
@@ -72,7 +72,7 @@
           <th>
             <SortableLink
               sortLabel="Payroll Specialist"
-              sortElement="payrollSpecialist"
+              sortElement="payrollSpecialist.0.user.displayName"
               :currentSort="currentSort"
               :currentSortDir="currentSortDir"
               @sort="sort"
@@ -117,6 +117,8 @@ import UserWithLink from "@/components/UserWithLink.vue";
 import SortableLink from "@/components/SortableLink.vue";
 import { dayjs } from "@/utils";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import { get as getValueAtPath, uniqBy } from "lodash";
+import { sortByValueAtPath } from "@/utils/sortByValueAtPath";
 
 export default {
   components: {
@@ -155,36 +157,14 @@ export default {
         outputObject.accountant = members.filter((m) => m.role.id == 11);
         listByDepartment.push(outputObject);
       }
-      return listByDepartment;
+
+      // dedupe
+      return uniqBy(listByDepartment, "dept_id");
     },
-    sortedListByDepartment: function () {
-      return [...this.listByDepartment].sort((a, b) => {
-        let modifier = 1;
-        if (this.currentSortDir === "desc") modifier = -1;
-
-        a = a?.[this.currentSort] || " ";
-        b = b?.[this.currentSort] || " ";
-
-        if (typeof a === "string") {
-          a = a.toLowerCase();
-        } else {
-          if (a[0] && a[0].user && a[0].user.displayName) {
-            a = a[0].user.displayName.toLowerCase();
-          }
-        }
-
-        if (typeof b === "string") {
-          b = b.toLowerCase();
-        } else {
-          if (b[0] && b[0].user && b[0].user.displayName) {
-            b = b[0].user.displayName.toLowerCase();
-          }
-        }
-
-        if (a < b) return -1 * modifier;
-        if (a > b) return 1 * modifier;
-        return 0;
-      });
+    sortedListByDepartment() {
+      return [...this.listByDepartment].sort(
+        sortByValueAtPath(this.currentSort, this.currentSortDir),
+      );
     },
   },
   async mounted() {

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -94,6 +94,10 @@ export interface MemberRole {
   updated_at: ISODateTime | null; // why null?
   deleted_at?: ISODateTime | null;
   official_role_category_id: number;
+  official_role_category?: {
+    id: number;
+    category: string; // "College" or "Unit"
+  };
   official_group_type: GroupType[];
   members?: Membership[];
 }
@@ -106,7 +110,7 @@ export interface ParentOrganization {
   child_organizations_recursive: ParentOrganization[];
 }
 
-export interface Group {
+export interface BaseGroup {
   id: number;
   user_can_edit: boolean; // current user can edit
   group_title: string | null; // "Anthropology";
@@ -117,13 +121,14 @@ export interface Group {
   private_group: 0 | 1;
   parent_group_id: number | null;
   parent_group: Group | null;
-  child_groups?: ChildGroup[]; // how deep will this go?
+  child_groups?: ChildGroup[];
+
+  include_child_groups?: boolean; // should child groups be included in the member list?
   google_group: string | null;
-  show_unit: 0 | 1;
+  show_unit?: 0 | 1;
   secret_hash: string;
   parent_organization: ParentOrganization;
   parent_organization_id: number;
-  active: 0 | 1;
   artifacts: GroupArtifact[];
   notes: string | null;
   members: Membership[];
@@ -132,24 +137,13 @@ export interface Group {
   deleted_at?: ISODateTime | null;
 }
 
-export interface ChildGroup {
-  id: number;
-  group_title: string;
-  group_type_id: number;
-  private_group: 0 | 1;
+export interface Group extends BaseGroup {
+  active: 0 | 1;
+}
+
+// TODO: unify `active` and `active_group` into a single field
+export interface ChildGroup extends BaseGroup {
   active_group: 0 | 1;
-  start_date: ISODate | null;
-  end_date: ISODate | null;
-  created_at: ISODateTime;
-  updated_at: ISODateTime;
-  deleted_at: ISODateTime | null;
-  parent_organization_id: number; // can this be null?
-  google_group: string | null;
-  show_unit: 0 | 1;
-  parent_group_id: number;
-  abbreviation: string | null;
-  dept_id: string | null;
-  notes: string | null;
 }
 
 export interface Artifact {

--- a/resources/js/utils/index.js
+++ b/resources/js/utils/index.js
@@ -4,3 +4,4 @@ export { default as axios } from "./axios";
 export { sortByName } from "./sortByName";
 export { getTempId, isTempId } from "./tempIdHelpers";
 export { parseIntFromRouteParam } from "./parseIntFromRouteParam";
+export { sortByValueAtPath } from "./sortByValueAtPath";

--- a/resources/js/utils/sortByValueAtPath.ts
+++ b/resources/js/utils/sortByValueAtPath.ts
@@ -1,0 +1,19 @@
+import { get as getValueAtPath } from "lodash-es";
+
+export const sortByValueAtPath =
+  (path: string, sortDirection: "asc" | "desc") => (a, b) => {
+    const modifier = sortDirection === "desc" ? -1 : 1;
+
+    // path is the key to sort on
+    // e.g. 'financeManager.0.user.displayName`
+    a = getValueAtPath(a, path) || " ";
+    b = getValueAtPath(b, path) || " ";
+
+    if (typeof a === "string" && typeof b === "string") {
+      return a.localeCompare(b) * modifier;
+    }
+
+    if (a < b) return -1 * modifier;
+    if (a > b) return 1 * modifier;
+    return 0;
+  };


### PR DESCRIPTION
Resolves #80 

This resolves sorting issues on the groups page, and in a few reports. The issue was that `currentSort` and sortable fields could be an object path like `user.surname` or `financeManager.0.user.displayName` not just a property name. I missed this when migrating to Vue3... any sort based on paths has probably been broken since then.

- As I was working through the issue, I added types to `<MemberList>` and `<SortableLink>` components.
- extracted the sort function to its own util, so it could be reused wherever broken
- added [some deduplication](https://github.com/UMN-LATIS/bluesheet/blob/97c39d0c6c76455fe1933c50ade5b0e03fe2f2c5/resources/js/pages/reports/FiscalReportPage.vue#L161-L162) to the the Fiscal Report. Vue was complaining multiple entries with the same dept id. (Is this correct? Are there ever supposed to be multiple entries from the same dept?)
- I noticed that parent `Group`s have an `active` property, while child groups have an `active_group` property which was causing some TS complaints. For now, I just have a separate type for child groups, but probably a better solution is to adjust the api (unless they mean different things).

On dev for testing: https://cla-groups-dev.oit.umn.edu/group/6