### PR TITLE
Layout for Leave Artifacts broken

### DIFF
--- a/resources/js/components/LeavesTable/LeavesTable.vue
+++ b/resources/js/components/LeavesTable/LeavesTable.vue
@@ -37,21 +37,19 @@
           <Th v-if="$can('edit leaves')"></Th>
         </tr>
       </THead>
-      <TBody>
-        <tr v-if="!sortedAndFilteredLeaves.length">
-          <Td
-            :colspan="$can('edit leaves') ? 6 : 5"
-            class="tw-text-center !tw-p-6 tw-italic tw-text-neutral-500"
-          >
-            No Leaves
-          </Td>
-        </tr>
-        <LeaveTableRow
-          v-for="leave in sortedAndFilteredLeaves"
-          :key="leave.id"
-          :leave="leave"
-        />
-      </TBody>
+      <tr v-if="!sortedAndFilteredLeaves.length">
+        <Td
+          :colspan="$can('edit leaves') ? 6 : 5"
+          class="tw-text-center !tw-p-6 tw-italic tw-text-neutral-500"
+        >
+          No Leaves
+        </Td>
+      </tr>
+      <LeaveTableRow
+        v-for="leave in sortedAndFilteredLeaves"
+        :key="leave.id"
+        :leave="leave"
+      />
     </Table>
   </div>
 </template>
@@ -61,7 +59,7 @@ import { computed, ref } from "vue";
 import { dayjs, $can, isTempId } from "@/utils";
 import { Leave } from "@/types";
 import Button from "@/components/Button.vue";
-import { Table, Th, Td, THead, TBody } from "@/components/Table";
+import { Table, Th, Td, THead } from "@/components/Table";
 import CheckboxGroup from "@/components/CheckboxGroup.vue";
 import LeaveTableRow from "./LeaveTableRow.vue";
 import { useUserStore } from "@/stores/useUserStore";


### PR DESCRIPTION
Fixes #106

![ScreenShot 2024-02-07 at 23 36 13@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/b5ec315c-b256-44fa-b8ef-8660fc2e702a)

Removes the extra <tbody> wrapping the main contents. 

We're using <tbody> to wrap the leave artifact details section. (There was probably a better way to go about this layout, but I wanted the details columns to align with the main artifact columns.)

Whatever the case, nested <tbody> is causing the problem. Tables can have multiple <tbody>, but I guess nested <tbody> is invalid. To resolve, this removes the main wrapping tbody.

