### PR TITLE
fix: Bandaid::getEmployees

### DIFF
--- a/app/Library/Bandaid.php
+++ b/app/Library/Bandaid.php
@@ -46,7 +46,7 @@ class Bandaid {
         $response = Http::withHeaders($this->headers)
             ->post(
                 $this->baseUri . $url,
-                ['form_params' => $body]
+                $body
             );
 
         $value = json_decode($response->body());

--- a/app/Library/Bandaid.php
+++ b/app/Library/Bandaid.php
@@ -243,4 +243,30 @@ class Bandaid {
             return ($isTermStartInRange || $isTermEndInRange);
         });
     }
+
+    /**
+     * This gets name info for a list of emplids. This can be used
+     * as a fallback when a user is not found in LDAP.
+     *
+     * @param int[] $emplids
+     * @return Collection<array{
+     * id: int,
+     * EMPLID: int,
+     * NAME: string,
+     * FIRST_NAME: string,
+     * LAST_NAME: string,
+     * MIDDLE_NAME: string,
+     * INTERNET_ID: string,
+     * }>
+     */
+    public function getNames(array $emplids): Collection {
+        try {
+            $result = $this->cachedPost('/names', ["emplids" => $emplids]);
+            return collect($result);
+        } catch (RequestException $e) {
+            $msg = $e->getMessage();
+            $errorMessage = 'getEmployees Error: ' . $msg;
+            throw new RuntimeException($errorMessage);
+        }
+    }
 }


### PR DESCRIPTION
- change how we're getting dept employees to fix issue where some courses aren't appearing if the instructor isn't technically part of the department
- remove wrapping post request with `form_params`.
- use names table for fallback if LDAP getting fails, and do a best attempt to create user