### PR TITLE
clear cache on deploy

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Deployer;
 // require 'contrib/laravel.php';
 require 'contrib/yarn.php';
@@ -23,33 +24,32 @@ $prodHost = 'cla-groups-prd.oit.umn.edu';
 $phpPath = '/opt/remi/php81/root/usr/bin/php';
 
 host('dev')
-  ->set('hostname', $devHost)
-  ->set('remote_user', 'swadm')
-  ->set('labels', ['stage' => 'development'])
-  // ->identityFile()
-  ->set('bin/php', $phpPath)
-  ->set('deploy_path', '/swadm/var/www/html/');
+    ->set('hostname', $devHost)
+    ->set('remote_user', 'swadm')
+    ->set('labels', ['stage' => 'development'])
+    // ->identityFile()
+    ->set('bin/php', $phpPath)
+    ->set('deploy_path', '/swadm/var/www/html/');
 
 host('stage')
-  ->set('hostname', $tstHost)
-  ->set('remote_user', 'swadm')
-  ->set('labels', ['stage' => 'stage'])
-  // ->identityFile()
-  ->set('bin/php', $phpPath)
-  ->set('deploy_path', '/swadm/var/www/html/');
+    ->set('hostname', $tstHost)
+    ->set('remote_user', 'swadm')
+    ->set('labels', ['stage' => 'stage'])
+    // ->identityFile()
+    ->set('bin/php', $phpPath)
+    ->set('deploy_path', '/swadm/var/www/html/');
 
 host('prod')
-  ->set('hostname', $prodHost)
-  ->set('remote_user', 'swadm')
-  ->set('labels', ['stage' => 'production'])
-  ->set('bin/php', $phpPath)
-  ->set('deploy_path', '/swadm/var/www/html/');
+    ->set('hostname', $prodHost)
+    ->set('remote_user', 'swadm')
+    ->set('labels', ['stage' => 'production'])
+    ->set('bin/php', $phpPath)
+    ->set('deploy_path', '/swadm/var/www/html/');
 
-task('assets:generate', function() {
-  cd('{{release_path}}');
-  run('yarn build');
+task('assets:generate', function () {
+    cd('{{release_path}}');
+    run('yarn build');
 })->desc('Assets generation');
-
 
 // [Optional] if deploy fails automatically unlock.
 after('deploy:failed', 'deploy:unlock');
@@ -68,3 +68,6 @@ before('deploy:symlink', 'artisan:migrate');
 after('deploy:update_code', 'yarn:install');
 after('yarn:install', 'assets:generate');
 after('artisan:migrate', 'artisan:queue:restart');
+
+// clear any cached bandaid or ldap info
+before('artisan:config:cache', 'artisan:cache:clear');

--- a/deploy.php
+++ b/deploy.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Deployer;
 // require 'contrib/laravel.php';
 require 'contrib/yarn.php';
@@ -24,32 +23,33 @@ $prodHost = 'cla-groups-prd.oit.umn.edu';
 $phpPath = '/opt/remi/php81/root/usr/bin/php';
 
 host('dev')
-    ->set('hostname', $devHost)
-    ->set('remote_user', 'swadm')
-    ->set('labels', ['stage' => 'development'])
-    // ->identityFile()
-    ->set('bin/php', $phpPath)
-    ->set('deploy_path', '/swadm/var/www/html/');
+  ->set('hostname', $devHost)
+  ->set('remote_user', 'swadm')
+  ->set('labels', ['stage' => 'development'])
+  // ->identityFile()
+  ->set('bin/php', $phpPath)
+  ->set('deploy_path', '/swadm/var/www/html/');
 
 host('stage')
-    ->set('hostname', $tstHost)
-    ->set('remote_user', 'swadm')
-    ->set('labels', ['stage' => 'stage'])
-    // ->identityFile()
-    ->set('bin/php', $phpPath)
-    ->set('deploy_path', '/swadm/var/www/html/');
+  ->set('hostname', $tstHost)
+  ->set('remote_user', 'swadm')
+  ->set('labels', ['stage' => 'stage'])
+  // ->identityFile()
+  ->set('bin/php', $phpPath)
+  ->set('deploy_path', '/swadm/var/www/html/');
 
 host('prod')
-    ->set('hostname', $prodHost)
-    ->set('remote_user', 'swadm')
-    ->set('labels', ['stage' => 'production'])
-    ->set('bin/php', $phpPath)
-    ->set('deploy_path', '/swadm/var/www/html/');
+  ->set('hostname', $prodHost)
+  ->set('remote_user', 'swadm')
+  ->set('labels', ['stage' => 'production'])
+  ->set('bin/php', $phpPath)
+  ->set('deploy_path', '/swadm/var/www/html/');
 
-task('assets:generate', function () {
-    cd('{{release_path}}');
-    run('yarn build');
+task('assets:generate', function() {
+  cd('{{release_path}}');
+  run('yarn build');
 })->desc('Assets generation');
+
 
 // [Optional] if deploy fails automatically unlock.
 after('deploy:failed', 'deploy:unlock');
@@ -69,5 +69,5 @@ after('deploy:update_code', 'yarn:install');
 after('yarn:install', 'assets:generate');
 after('artisan:migrate', 'artisan:queue:restart');
 
-// clear any cached bandaid or ldap info
+// clear any cached data, like cached instructor info,
 before('artisan:config:cache', 'artisan:cache:clear');


### PR DESCRIPTION
Resolves #118 

The resulting task-tree:

```
└── deploy
    ├── deploy:prepare
    │   ├── deploy:info
    │   ├── deploy:setup
    │   ├── deploy:lock
    │   ├── deploy:release
    │   ├── deploy:update_code
    │   ├── deploy:git:submodules  // after deploy:update_code
    │   ├── yarn:install  // after deploy:update_code
    │   ├── assets:generate  // after yarn:install
    │   ├── deploy:shared
    │   └── deploy:writable
    ├── deploy:vendors
    ├── artisan:storage:link
    ├── artisan:cache:clear  // before artisan:config:cache
    ├── artisan:config:cache
    ├── artisan:route:cache
    ├── artisan:view:cache
    ├── artisan:event:cache
    ├── artisan:migrate
    ├── artisan:queue:restart  // after artisan:migrate
    └── deploy:publish
        ├── artisan:migrate  // before deploy:symlink
        ├── artisan:queue:restart  // after artisan:migrate
        ├── deploy:symlink
        ├── deploy:unlock
        ├── deploy:cleanup
        └── deploy:success
```


