### PR TITLE
Add "Leave impersonation" button to top of page when impersonation

### DIFF
--- a/resources/views/base.blade.php
+++ b/resources/views/base.blade.php
@@ -13,14 +13,40 @@
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.0/css/all.css"
     integrity="sha384-aOkxzJ5uQz7WBObEZcHvV5JvRW3TUc2rNPA7pe3AwnsUohiw1Vj2Rgx2KSOkF5+h" crossorigin="anonymous">
   @vite(['resources/js/app.js'])
+
+  <style>
+    .impersonation-header {
+      background-color: #c42da8;
+      color: white;
+    }
+
+    .impersonation-header__inner {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      max-width: 90rem;
+      padding: 0.5rem 1rem;
+      margin: 0 auto;
+    }
+  </style>
 </head>
 
 <body>
+  @impersonating($guard = null)
+    <div class="impersonation-header">
+      <div class="impersonation-header__inner">
+        <div>{{ auth()->user()->displayName }}</div>
+
+        <div>
+          <a class="btn btn-outline-light" href="{{ route('impersonate.leave') }}">Leave impersonation</a>
+        </div>
+      </div>
+    </div>
+  @endImpersonating
+
+
   @yield('content')
 
-  @impersonating
-    <a class="" href="/impersonate/leave">End Impersonation</a>
-  @endImpersonating
   @yield('footer')
 
   <script>


### PR DESCRIPTION
![ScreenShot 2024-03-18 at 12 49 56@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/45085abd-d661-4446-ab46-91426a164fc5)

Adds the name of the impersonated user and a "Leave Impersonation" button to the top of the page when a user is impersonated.

Before, there actually was a link – but it was easily lost below the footer.

Fixes #121