### PR TITLE
fix: <InputGroup> not passing `required` prop to `<Label>`

### DIFF
--- a/resources/js/components/InputGroup.vue
+++ b/resources/js/components/InputGroup.vue
@@ -2,7 +2,7 @@
   <div class="form-group tw-mb-0">
     <Label
       :for="inputId"
-      :required="true"
+      :required="required"
       :class="[
         {
           'sr-only': !showLabel,

--- a/resources/js/components/LeavesTable/LeaveArtifactRow.vue
+++ b/resources/js/components/LeavesTable/LeaveArtifactRow.vue
@@ -5,6 +5,7 @@
       <Td colspan="3">
         <InputGroup
           v-model="localArtifact.label"
+          :required="true"
           label="Label"
           placeholder="Artifact Label"
           :showLabel="false"
@@ -15,6 +16,7 @@
       <Td colspan="2">
         <InputGroup
           v-model="localArtifact.target"
+          :required="true"
           label="URL"
           :showLabel="false"
           placeholder="Artifact URL"

--- a/resources/js/components/LeavesTable/LeaveTableRow.vue
+++ b/resources/js/components/LeavesTable/LeaveTableRow.vue
@@ -33,6 +33,7 @@
       <InputGroup
         v-if="isEditing"
         v-model="localLeave.description"
+        :required="true"
         label="description"
         :showLabel="false"
         :validator="isNotEmptyString"
@@ -80,6 +81,7 @@
       <InputGroup
         v-if="isEditing"
         v-model="localLeave.start_date"
+        :required="true"
         label="start date"
         :showLabel="false"
         type="date"
@@ -101,6 +103,7 @@
         v-if="isEditing"
         v-model="localLeave.end_date"
         label="start date"
+        :required="true"
         :showLabel="false"
         type="date"
         :validator="


### PR DESCRIPTION
Resolves an issue where the `<Label>`'s `:required` prop was hard-coded to `true` in the `<InputGroup>`. This would mark non-required fields as optional.

Also adds "required" prop to any `InputGroup`'s requiring an input.

This issue came up when working on #112.