### PR TITLE
Leave Planning Report: Add filter for minimum section enrollment.

### DIFF
--- a/resources/js/features/course-planning/components/CoursePlanningFilters.vue
+++ b/resources/js/features/course-planning/components/CoursePlanningFilters.vue
@@ -124,6 +124,27 @@
           <span class="tw-text-neutral-400 tw-text-xs ml-1">({{ count }})</span>
         </label>
       </fieldset>
+      <fieldset>
+        <div class="tw-flex tw-items-baseline tw-mb-1">
+          <legend
+            class="tw-uppercase tw-text-xs tw-text-neutral-500 tw-tracking-wide tw-font-semibold tw-my-1"
+          >
+            Minimum Enrollment
+          </legend>
+        </div>
+        <InputGroup
+          :modelValue="String(filters.minSectionEnrollment)"
+          label="Minimum Enrollment"
+          type="number"
+          placeholder="0"
+          class="tw-w-20"
+          :required="false"
+          :showLabel="false"
+          @update:modelValue="
+            filters.minSectionEnrollment = Number.parseInt($event)
+          "
+        />
+      </fieldset>
     </div>
   </section>
 </template>
@@ -133,6 +154,7 @@ import SelectGroup from "@/components/SelectGroup.vue";
 import Button from "@/components/Button.vue";
 import { useCoursePlanningStore } from "../stores/useCoursePlanningStore";
 import { storeToRefs } from "pinia";
+import InputGroup from "@/components/InputGroup.vue";
 
 const coursePlanningStore = useCoursePlanningStore();
 

--- a/resources/js/features/course-planning/components/CoursePlanningFilters.vue
+++ b/resources/js/features/course-planning/components/CoursePlanningFilters.vue
@@ -133,28 +133,26 @@
           </legend>
         </div>
         <InputGroup
-          :modelValue="String(filters.minSectionEnrollment)"
+          v-model="minSectionEnrollmentRaw"
           label="Minimum Enrollment"
           type="number"
           placeholder="0"
           class="tw-w-20"
           :required="false"
           :showLabel="false"
-          @update:modelValue="
-            filters.minSectionEnrollment = Number.parseInt($event)
-          "
         />
       </fieldset>
     </div>
   </section>
 </template>
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 import SelectGroup from "@/components/SelectGroup.vue";
 import Button from "@/components/Button.vue";
 import { useCoursePlanningStore } from "../stores/useCoursePlanningStore";
 import { storeToRefs } from "pinia";
 import InputGroup from "@/components/InputGroup.vue";
+import { debounce } from "lodash";
 
 const coursePlanningStore = useCoursePlanningStore();
 
@@ -170,6 +168,15 @@ const {
 
 const termSelectOptions = computed(
   () => coursePlanningStore.termsStore.termSelectOptions,
+);
+
+const minSectionEnrollmentRaw = ref("");
+
+watch(
+  minSectionEnrollmentRaw,
+  debounce((value) => {
+    coursePlanningStore.setMinSectionEnrollment(value);
+  }, 500),
 );
 </script>
 <style scoped></style>

--- a/resources/js/features/course-planning/stores/useCoursePlanningStore.ts
+++ b/resources/js/features/course-planning/stores/useCoursePlanningStore.ts
@@ -39,7 +39,7 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
       excludedCourseLevels: new Set(),
       excludedAcadAppts: new Set(),
       includedEnrollmentRoles: new Set(["PI"]),
-      minSectionEnrollment: 0,
+      minSectionEnrollment: "",
       search: "",
     },
   });
@@ -322,6 +322,7 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
       state.filters.excludedAcadAppts = new Set();
       state.filters.excludedCourseLevels = new Set();
       state.filters.excludedCourseTypes = new Set();
+      state.filters.minSectionEnrollment = "";
 
       const earliestTerm = stores.termsStore.earliestTerm;
       const latestTerm = stores.termsStore.latestTerm;
@@ -471,6 +472,16 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
       if (!course) return false;
       return methods.isCourseMatchingSearch(course);
     },
+    doesSectionHaveMinEnrollment(section: T.CourseSection) {
+      const minEnrollmentInt = Number.parseInt(
+        state.filters.minSectionEnrollment,
+      );
+
+      if (Number.isNaN(minEnrollmentInt)) {
+        return true;
+      }
+      return section.enrollmentTotal >= minEnrollmentInt;
+    },
 
     isTermVisible(termId: T.Term["id"]) {
       if (!state.filters.startTermId || !state.filters.endTermId) {
@@ -531,8 +542,14 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
         course.courseLevel,
       );
 
+      const doesSectionHaveMinEnrollment =
+        methods.doesSectionHaveMinEnrollment(section);
+
       return (
-        isSectionTermVisible && isCourseTypeVisible && isCourseLevelVisible
+        isSectionTermVisible &&
+        isCourseTypeVisible &&
+        isCourseLevelVisible &&
+        doesSectionHaveMinEnrollment
       );
     },
 

--- a/resources/js/features/course-planning/stores/useCoursePlanningStore.ts
+++ b/resources/js/features/course-planning/stores/useCoursePlanningStore.ts
@@ -546,14 +546,11 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
         course.courseLevel,
       );
 
-      const doesSectionHaveMinEnrollment =
-        methods.doesSectionHaveMinEnrollment(section);
-
       return (
         isSectionTermVisible &&
         isCourseTypeVisible &&
         isCourseLevelVisible &&
-        doesSectionHaveMinEnrollment
+        methods.doesSectionHaveMinEnrollment(section)
       );
     },
 

--- a/resources/js/features/course-planning/stores/useCoursePlanningStore.ts
+++ b/resources/js/features/course-planning/stores/useCoursePlanningStore.ts
@@ -39,6 +39,7 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
       excludedCourseLevels: new Set(),
       excludedAcadAppts: new Set(),
       includedEnrollmentRoles: new Set(["PI"]),
+      minSectionEnrollment: 0,
       search: "",
     },
   });

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -372,7 +372,7 @@ export interface CoursePlanningFilters {
   excludedCourseLevels: Set<string>;
   excludedCourseTypes: Set<string>;
   excludedAcadAppts: Set<string>;
-  minSectionEnrollment: number;
+  minSectionEnrollment: string;
   includedEnrollmentRoles: Set<EnrollmentRole>;
   search: string;
   inPlanningMode: boolean;

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -372,6 +372,7 @@ export interface CoursePlanningFilters {
   excludedCourseLevels: Set<string>;
   excludedCourseTypes: Set<string>;
   excludedAcadAppts: Set<string>;
+  minSectionEnrollment: number;
   includedEnrollmentRoles: Set<EnrollmentRole>;
   search: string;
   inPlanningMode: boolean;

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -372,7 +372,7 @@ export interface CoursePlanningFilters {
   excludedCourseLevels: Set<string>;
   excludedCourseTypes: Set<string>;
   excludedAcadAppts: Set<string>;
-  minSectionEnrollment: string;
+  minSectionEnrollment: number;
   includedEnrollmentRoles: Set<EnrollmentRole>;
   search: string;
   inPlanningMode: boolean;


### PR DESCRIPTION
![ScreenShot 2024-03-18 at 16 06 38@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/fb88f4e4-1378-4c16-b202-e9005c56f262)

This permits users to filter displayed sections based on their enrollment count. Defaults to 0.

Closes #102.