### PR TITLE
rename `group admin` role as `global group admin`

### DIFF
--- a/app/Http/Resources/MembershipWithGroups.php
+++ b/app/Http/Resources/MembershipWithGroups.php
@@ -20,7 +20,7 @@ class MembershipWithGroups extends JsonResource {
      */
     public function toArray($request) {
         $group = $this->group;
-        if ($group->private_group && Auth::user()->id !== $this->user_id && !Auth::user()->can('group admin')) {
+        if ($group->private_group && Auth::user()->id !== $this->user_id && !Auth::user()->can('global group admin')) {
             $group->group_title = "Private Group";
             $group->id = null;
         }

--- a/database/migrations/2024_03_22_025035_change_group_admin_role_to_global-group-admin.php
+++ b/database/migrations/2024_03_22_025035_change_group_admin_role_to_global-group-admin.php
@@ -12,6 +12,7 @@ return new class extends Migration {
     public function up(): void {
 
         PermissionRole::where('name', 'group admin')->update(['name' => 'global group admin']);
+        app()->make(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
     }
 
     /**
@@ -19,5 +20,6 @@ return new class extends Migration {
      */
     public function down(): void {
         PermissionRole::where('name', 'global group admin')->update(['name' => 'group admin']);
+        app()->make(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
     }
 };

--- a/database/migrations/2024_03_22_025035_change_group_admin_role_to_global-group-admin.php
+++ b/database/migrations/2024_03_22_025035_change_group_admin_role_to_global-group-admin.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Role as PermissionRole;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+
+        PermissionRole::where('name', 'group admin')->update(['name' => 'global group admin']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        PermissionRole::where('name', 'global group admin')->update(['name' => 'group admin']);
+    }
+};

--- a/database/seeders/TestUsersSeeder.php
+++ b/database/seeders/TestUsersSeeder.php
@@ -51,7 +51,7 @@ class TestUsersSeeder extends Seeder {
             'umndid' => 'group_admin',
             'emplid' => '1111116',
         ])->create();
-        $groupAdmin->assignRole('group admin');
+        $groupAdmin->assignRole('global group admin');
 
         $siteAdmin = User::factory([
             'givenname' => 'Site',


### PR DESCRIPTION
This is related to work on scoping group admin permissions to specific groups and #92 .

Currently, there's a `group admin` role (Spatie Role) permits administration of any group or user leaves. This is different than permissions granted when the `admin` flag is set on a member of a group. This renames the role to `global group admin` to make thnigs clearer until scoping work is complete and we can migrate users with global permissions to scoped permissions. After that functionality is done, we may be able remove this role all together.

On dev for testing