### PR TITLE
Fix empty emulated user display names when logging as a fake user when emulating shib

### DIFF
--- a/app/Http/Middleware/PopulateUser.php
+++ b/app/Http/Middleware/PopulateUser.php
@@ -8,6 +8,45 @@ use App\Library\LDAP as LDAP;
 
 class populateUser
 {
+    protected function isEmulatingShib() {
+        return config('shibboleth.emulate_idp');
+    }
+
+    protected function isEmulatedUser($umndid) {
+        return array_key_exists($umndid, config('shibboleth.emulate_idp_users'));
+    }
+
+    protected function getEmulatedUser($umndid) {
+        if (!$this->isEmulatedUser($umndid)) {
+            throw new \Exception("User {$umndid} is not an emulated user.");
+        }
+
+        $usernameParts = explode('_', $umndid, 2);
+        $firstName = ucfirst($usernameParts[0]);
+        $lastName = ucfirst($usernameParts[1]) ?? "Mc{$firstName}Face";
+
+        return (object) [
+            'umndid' => $umndid,
+            'displayName' => "{$firstName} {$lastName}",
+            'givenname' => $firstName,
+            'surname' => $lastName,
+            'email' => "{$umndid}@umn.edu",
+            'office' => 'LATIS $ 110 AndH $ 257 19th Ave S $ Minneapolis, MN 55455-0425',
+            'ou' => 'Lib Arts-TC'
+        ];
+    }
+
+    /**
+     * Lookup a user in LDAP, unless we're emulating
+     */
+    protected function lookupUser($lookupValue) {
+        if ($this->isEmulatingShib() && $this->isEmulatedUser($lookupValue)) {
+            return $this->getEmulatedUser($lookupValue);
+        }
+
+        return LDAP::lookupUserCached($lookupValue, "umndid");
+    }
+
     /**
      * Handle an incoming request.
      *
@@ -15,11 +54,11 @@ class populateUser
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next)
-    {
-        if(Auth::user() && !Auth::user()->displayName) {
+    public function handle($request, Closure $next) {
+        if (Auth::user() && !Auth::user()->displayName) {
             $foundUser = LDAP::lookupUser(Auth::user()->umndid, "umndid");
-            if($foundUser) {
+
+            if ($foundUser) {
                 Auth::user()->surname = $foundUser->surname;
                 Auth::user()->givenname = $foundUser->givenname;
                 Auth::user()->displayName = $foundUser->displayName;

--- a/config/shibboleth.php
+++ b/config/shibboleth.php
@@ -31,80 +31,34 @@ return array(
      */
 
     'emulate_idp'       => env('SHIB_EMULATE', false),
-    'emulate_idp_users' => array(
-        'admin' => array(
-            'uid'         => 'admin',
-            'displayName' => 'Admin User',
-            'givenName'   => 'Admin',
-            'surname'   => 'McAdmin',
-            'sn'          => 'User',
+    'emulate_idp_users' => [
+        // name info is populated via populateUser middleware
+        'admin' => [
             'eppn'        => 'admin@umn.edu',
             'umnDID'      => 'admin',
             'umnEmplId'      => '1111111',
-        ),
-        'staff' => array(
-            'uid'         => 'staff',
-            'displayName' => 'Staff User',
-            'givenName'   => 'Staff',
-            'surName'   => 'McStaff',
-            'sn'          => 'User',
-            'eppn'        => 'staff@umn.edu',
-            'umnDID'      => 'staff',
-            'umnEmplId'      => '1111112',
-        ),
-        'user'  => array(
-            'uid'         => 'user',
-            'displayName' => 'User User',
-            'givenName'   => 'User',
-            'surname'   => 'McUser',
-            'sn'          => 'User',
-            'mail'        => 'user@umn.edu',
-            'umnDID'      => 'user',
-            'umnEmplId'      => '1111113',
-        ),
-
-        // users for testing roles
+        ],
         'basic_user' => [
-            'uid' => 'basic_user',
-            'displayName' => 'Basic User',
-            'givenName' => 'Basic',
-            'surname' => 'User',
-            'sn' => 'User',
-            'mail' => 'basic_user@umn.edu',
+            'eppn' => 'basic_user@umn.edu',
             'umnDID' => 'basic_user',
             'umnEmplId'      => '1111114',
         ],
         'view_user' => [
-            'uid' => 'view_user',
-            'displayName' => 'View User',
-            'givenName' => 'View',
-            'surname' => 'User',
-            'sn' => 'User',
-            'mail' => 'view_user@umn.edu',
+            'eppn' => 'view_user@umn.edu',
             'umnDID' => 'view_user',
             'umnEmplId'      => '1111115',
         ],
         'group_admin' => [
-            'uid' => 'group_admin',
-            'displayName' => 'Group Admin',
-            'givenName' => 'Group',
-            'surname' => 'Admin',
-            'sn' => 'Admin',
-            'mail' => 'group_admin@umn.edu',
+            'eppn' => 'group_admin@umn.edu',
             'umnDID' => 'group_admin',
             'umnEmplId'      => '1111116',
         ],
         'site_admin' => [
-            'uid' => 'site_admin',
-            'displayName' => 'Site Admin',
-            'givenName' => 'Site',
-            'surname' => 'Admin',
-            'sn' => 'Admin',
-            'mail' => 'site_admin@umn.edu',
+            'eppn' => 'site_admin@umn.edu',
             'umnDID' => 'site_admin',
             'umnEmplId'      => '1111117',
         ]
-    ),
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -122,9 +76,6 @@ return array(
         'email'       => 'eppn',
         'umndid' => 'umnDID',
         'emplid' => 'umnEmplId',
-        // 'surname' => 'surname',
-        // 'givenname' => 'givenName',
-        // 'displayname' => 'displayName',
     ],
 
     /*


### PR DESCRIPTION
Currently, when emulating shib and logging in as an emulated user (e.g. `view_user`), the user's name info will be blank since this data comes from the LDAP via the `populateUser` middleware. 

This:
- updates the populateUser to construct fake name info for these emulated users when in shib emulation mode.
- removes non-shib info from `emulate_idp_users`
