### PR TITLE
fix user page rendering for default users

### DIFF
--- a/resources/js/api/api.ts
+++ b/resources/js/api/api.ts
@@ -12,12 +12,18 @@ export async function lookupUsers(query: string): Promise<T.UserLookupItem[]> {
 
 export async function fetchUser(userId: number): Promise<T.User> {
   const res = await axios.get<T.ApiUserResponse>(`/api/user/${userId}`);
-  return res.data;
+  return {
+    ...res.data,
+    leaves: res.data.leaves ?? [],
+  };
 }
 
-export async function updateUser(user: T.User) {
-  const res = await axios.put<T.User>(`/api/user/${user.id}`, user);
-  return res.data;
+export async function updateUser(user: T.User): Promise<T.User> {
+  const res = await axios.put<T.ApiUserResponse>(`/api/user/${user.id}`, user);
+  return {
+    ...res.data,
+    leaves: res.data.leaves ?? [],
+  };
 }
 
 export async function createLeave(leave: T.NewLeave) {

--- a/resources/js/pages/UserHomePage.vue
+++ b/resources/js/pages/UserHomePage.vue
@@ -37,7 +37,7 @@
       <Roles id="v-step-4" :memberships="memberships" class="tw-mt-12"></Roles>
 
       <LeavesTable
-        v-if="user && user.leaves"
+        v-if="$can('view leaves') || isCurrentUser || $can('edit leaves')"
         :leaves="user.leaves"
         :userId="user.id"
         class="tw-mt-12"
@@ -56,6 +56,7 @@ import CheckboxGroup from "@/components/CheckboxGroup.vue";
 import DefaultLayout from "@/layouts/DefaultLayout.vue";
 import { usePageTitle } from "@/utils/usePageTitle";
 import { useUserStore } from "@/stores/useUserStore";
+import { $can } from "@/utils";
 
 const props = defineProps<{
   userId: number | null;

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -384,6 +384,7 @@ export interface SerializedCoursePlanningFilters {
   excludedCourseLevels: string[];
   excludedCourseTypes: string[];
   excludedAcadAppts: string[];
+  minSectionEnrollment: number;
   includedEnrollmentRoles: EnrollmentRole[];
   search: string;
   inPlanningMode: boolean;

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -324,7 +324,10 @@ export interface ApiCourseSectionRecord {
 }
 
 // api response types
-export type ApiUserResponse = User;
+export interface ApiUserResponse extends BaseUser {
+  leaves?: Leave[];
+}
+
 export type ApiGroupMembersReponse = Membership[];
 export type ApiGroupRolesResponse = MemberRole[];
 export type ApiGroupResponse = Group;


### PR DESCRIPTION
A default `view user` should be able to see other user's data and roles, but not their leaves. When a `view user` requests data from the api, the `leaves` property on the user object will be undefined. This is correct, but not properly handled on the front end.

Currently, the frontend expects users to have the same shape, with a defined (but possibly empty) `leaves` list. So userStore throws an error when mapping over the undefined `leaves` resulting in a blank page for the `view user`.

This PR handles undefined leaves value from the API. 

- the type of the `ApiUserResponse` is updated to account for undefined leaves.
- undefined leaves values are transformed into empty leaves array so that all user data has the same shape.
- to handle leave viewing, rather than using defined `user.leaves` as a proxy for permissions to view, we explicitly check whether the user can view/edit leaves or is current user. If not, no table will be rendered.
- Another type error was found when correcting this: a missing `minSectionEnrollment` value on the serialized filter type, so I fixed that at the same time.

Before:
![ScreenShot 2024-03-22 at 15 18 29@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/a3289eec-0b06-4209-b9d0-185f9c757b77)

After:
![ScreenShot 2024-03-22 at 15 53 52@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/7767b8ba-047e-4344-90ff-3a1a640dd0d4)

On dev for testing
