### PR TITLE
add "impersonate user" to the  admin "edit" view

### DIFF
--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -9,6 +9,11 @@
                 <div class="card">
                     <div class="card-header">Edit users #{{ $user->id }}</div>
                     <div class="card-body">
+                        @canImpersonate
+                          <a href="{{ route('impersonate', $user->id) }}">
+                            Impersonate this user
+                          </a>
+                        @endCanImpersonate
                         <a href="{{ url('/admin/users') }}" title="Back"><button class="btn btn-warning btn-sm"><i class="fa fa-arrow-left" aria-hidden="true"></i> Back</button></a>
                         <br />
                         <br />


### PR DESCRIPTION
![ScreenShot 2024-04-03 at 10 48 18@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/af3dbf07-3bd3-477b-a2ae-fb7ae3b728b9)

Adds impersonate user to admin "edit" view in addition to "show" view. This makes the flow for testing group managers a bit easier.

Fixes #138