### PR TITLE
fix: leaves planning report doesn't always show newly created leaves because of cache

### DIFF
--- a/app/Http/Controllers/CoursePlanning/GroupLeaveController.php
+++ b/app/Http/Controllers/CoursePlanning/GroupLeaveController.php
@@ -22,7 +22,7 @@ class GroupLeaveController extends Controller {
     public function index(Request $request, Group $group) {
         abort_if($request->user()->cannot('view leaves'), 403);
 
-        $employees = $this->userService->getDeptInstructors($group->dept_id);
+        $employees = $this->userService->getDeptInstructors($group->dept_id, ['refresh' => true]);
 
         return $employees->flatMap(function ($employee) {
             return $employee->leaves;

--- a/app/Library/UserService.php
+++ b/app/Library/UserService.php
@@ -104,8 +104,19 @@ class UserService {
         return $users->first();
     }
 
-    public function getDeptInstructors(string $deptId): Collection {
+    public function getDeptInstructors(string $deptId, array $options = []): Collection {
         $cacheKey = 'deptInstructors-' . $deptId;
+
+        $defaultOptions = [
+            'refresh' => false,
+        ];
+
+        $options = array_merge($defaultOptions, $options);
+
+        if ($options['refresh']) {
+            Cache::forget($cacheKey);
+        }
+
         $cachedInstructors = Cache::get($cacheKey);
         if ($cachedInstructors) {
             return $cachedInstructors;


### PR DESCRIPTION
Fixes #135

`UserService::getDeptInstructors` can now optionally refresh the cache. `GroupLeaveController@index` will always ask for fresh data.

Not deployed (yet) to dev, but this is what it looks like locally:


https://github.com/UMN-LATIS/bluesheet/assets/980170/a9058a1b-a18e-4eaf-aaad-3dee4b7bf404

