### PR TITLE
improve error handling for lookup user

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -185,7 +185,7 @@ class UserController extends Controller {
         } else if (count($outputArray) == 0) {
             $returnData['status'] = "Error";
             $returnData['message'] = "We couldn't find that user.";
-            $code = 500;
+            $code = 404;
         } else {
             $returnData['status'] = "Partial";
             $returnData['users'] = $outputArray;

--- a/resources/js/components/UserLookup.vue
+++ b/resources/js/components/UserLookup.vue
@@ -41,7 +41,13 @@
 
     <div class="form-group row">
       <div class="col-sm-3">
-        <button class="btn btn-primary" @click="lookupUser">Find User</button>
+        <button
+          class="btn btn-primary"
+          :disabled="!userLookupId"
+          @click="lookupUser"
+        >
+          Find User
+        </button>
       </div>
     </div>
     <div class="row">
@@ -59,6 +65,7 @@
 <script>
 import Modal from "./Modal.vue";
 import PersonSearch from "./PersonSearch.vue";
+import { axios } from "@/utils";
 
 export default {
   components: {
@@ -96,8 +103,18 @@ export default {
       });
     },
     lookupUser: function () {
+      if (!this.userLookupId) {
+        return;
+      }
+
       axios
-        .post("/api/user/lookup", { users: this.userLookupId })
+        .post(
+          "/api/user/lookup",
+          { users: this.userLookupId },
+          {
+            skipErrorNotifications: true,
+          },
+        )
         .then((res) => {
           if (res.data.users.length == 1) {
             this.$router.push({
@@ -114,7 +131,7 @@ export default {
           }
         })
         .catch((err) => {
-          this.findUserError = err.response.data.message;
+          this.findUserError = err.data.message;
         });
     },
   },


### PR DESCRIPTION
![ScreenShot 2024-04-03 at 13 26 57@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/02aa4cd4-e792-4efa-a2fa-de39dfab1948)

Previously, when Find User fails, the axios interceptor would display a 500 error modal.

This:
- disables "Find User" button when input is empty
- returns 404 instead of 500 when user(s) not found
- skips axios error notification interceptor so that we can manually handle error
- fix error message

resolves #119 

on dev for testing