### PR TITLE
show admin column in Group view mode if user can edit groups

### DIFF
--- a/resources/js/components/MemberList.vue
+++ b/resources/js/components/MemberList.vue
@@ -96,12 +96,14 @@
         ></i>
         <i v-else class="searchIcon fa fa-close"></i>
       </td>
-      <td v-if="editing" class="text-right">
+      <td v-if="editing || $can('edit groups')" class="tw-text-center">
         <input
+          v-if="editing"
           v-model="member.admin"
           class="form-check-input"
           type="checkbox"
         />
+        <CheckIcon v-else-if="member.admin" />
       </td>
       <td v-if="editing">
         <button class="btn btn-danger" @click="$emit('remove', member)">
@@ -116,11 +118,13 @@
 import GroupTitle from "./GroupTitle.vue";
 import { dayjs, $can } from "@/utils";
 import ComboBox from "./ComboBox.vue";
+import { CheckIcon } from "@/icons";
 
 export default {
   components: {
     GroupTitle,
     ComboBox,
+    CheckIcon,
   },
   props: [
     "editing",

--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -179,7 +179,9 @@
               @sort="sort"
             />
           </th>
-          <th v-if="editing && !showGantt" scope="col">Group Admin</th>
+          <th v-if="!showGantt && (editing || $can('edit groups'))" scope="col">
+            Group Admin
+          </th>
           <th v-if="editing && !showGantt" scope="col">
             End Active Membership
           </th>
@@ -417,8 +419,11 @@ export default defineComponent({
       });
     },
     compositeList(): MembershipWithMaybeChildGroupTitle[] {
-
-      if (!this.group || !this.group.include_child_groups || !this.group.child_groups) {
+      if (
+        !this.group ||
+        !this.group.include_child_groups ||
+        !this.group.child_groups
+      ) {
         return this.members;
       }
 


### PR DESCRIPTION
![ScreenShot 2024-04-03 at 13 47 17@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/7654e820-dcd8-4934-8ac1-e1ac66f5537b)

When a user has the global `edit groups` permissions, the `Group Admin` column will show up in view mode to make it easier to see which users have been granted admin permissions.

