### PR TITLE
fix: cancelling a new leave

### DIFF
--- a/resources/js/components/LeavesTable/LeaveTableRow.vue
+++ b/resources/js/components/LeavesTable/LeaveTableRow.vue
@@ -201,6 +201,10 @@ function handleEditClick() {
 }
 
 function handleCancelEditLeave() {
+  if (isNewLeave.value) {
+    userStore.removeLeaveFromStore(props.leave.id);
+  }
+
   isEditing.value = false;
   resetLocalLeaveToProps();
 }

--- a/tests/cypress/integration/userLeaves.test.ts
+++ b/tests/cypress/integration/userLeaves.test.ts
@@ -89,6 +89,29 @@ describe("User leaves", () => {
         });
     });
 
+    it("cancels the creation of a new leave", () => {
+      cy.visit(`/user/${basicUserId}`);
+
+      // verify that only 2 leaves exist
+      cy.get("[data-cy=leaveRow]").should("have.length", 2);
+
+      // add a leave
+      cy.contains("Add Leave").click();
+
+      // now should have 3 rows
+      cy.get("[data-cy=leaveRow]").should("have.length", 3);
+
+      // cancel the new leave
+      cy.get('[data-cy="leavesSection"] .is-new-leave')
+        .first()
+        .within(() => {
+          cy.get("button").contains("Cancel").click();
+        });
+
+      // now should have 2 rows again
+      cy.get("[data-cy=leaveRow]").should("have.length", 2);
+    });
+
     it("edits a leave", () => {
       cy.visit(`/user/${basicUserId}`);
       cy.get("[data-cy=leaveRow]")


### PR DESCRIPTION
When a user clicks "Add Leave" and then cancel, the leave will persist in the local store – showing an extra row to the users. (No actual new leave is created.)

This fixes the issue, removing the leave from the local store when the Cancel button is clicked. Adds a corresponding test.
