### PR TITLE
BlueSheet managers can view/modify leaves of subgroup members

### DIFF
--- a/app/Group.php
+++ b/app/Group.php
@@ -72,6 +72,12 @@ class Group extends Model implements AuditableContract {
         return $this->hasMany("App\Group", "parent_group_id");
     }
 
+    public function getDescendentGroups() {
+        return $this->childGroups->flatMap(function ($group) {
+            return collect([$group])->merge($group->getDescendentGroups());
+        });
+    }
+
     public function courseSections(): HasMany {
         return $this->hasMany(CourseSection::class);
     }

--- a/app/Policies/LeavePolicy.php
+++ b/app/Policies/LeavePolicy.php
@@ -29,8 +29,8 @@ class LeavePolicy {
     /**
      * Determine whether the user can create models.
      */
-    public function create(User $user): bool {
-        return $user->can(Permissions::EDIT_ANY_LEAVES);
+    public function create(User $user, Leave $leaveToCreate): bool {
+        return $this->modifyLeavesForUser($user, $leaveToCreate->user);
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -97,7 +97,14 @@ class User extends Authenticatable implements Auditable {
      * @return Collection<array-key, mixed>
      */
     public function getManagedGroups() {
-        return $this->memberships()->where('admin', true)->get()->pluck('group');
+        $managedGroups =  $this->memberships()->where('admin', true)->get()->pluck('group');
+
+        // get subgroups for each managed groups
+        $subgroups = $managedGroups->map(function ($group) {
+            return $group->childGroups;
+        })->flatten();
+
+        return $managedGroups->merge($subgroups)->unique('id');
     }
 
     public function managesAnyGroupWithMember(User $member): bool {

--- a/app/User.php
+++ b/app/User.php
@@ -101,7 +101,7 @@ class User extends Authenticatable implements Auditable {
 
         // get subgroups for each managed groups
         $subgroups = $managedGroups->map(function ($group) {
-            return $group->childGroups;
+            return $group->getDescendentGroups();
         })->flatten();
 
         return $managedGroups->merge($subgroups)->unique('id');

--- a/tests/cypress/integration/userLeaves.test.ts
+++ b/tests/cypress/integration/userLeaves.test.ts
@@ -313,7 +313,7 @@ describe("User leaves", () => {
         cy.get("[data-cy=leaveRow]").should("have.length", 0);
       });
 
-      it.only("allows a group manager to view leaves for a subgroup member", () => {
+      it("allows a group manager to view leaves for a subgroup member", () => {
         // create a subgroup
         cy.create({
           model: "App\\Group",

--- a/tests/cypress/integration/userLeaves.test.ts
+++ b/tests/cypress/integration/userLeaves.test.ts
@@ -312,6 +312,42 @@ describe("User leaves", () => {
 
         cy.get("[data-cy=leaveRow]").should("have.length", 0);
       });
+
+      it.only("allows a group manager to view leaves for a subgroup member", () => {
+        // create a subgroup
+        cy.create({
+          model: "App\\Group",
+          attributes: {
+            parent_group_id: fellowGroupMembership.group_id,
+          },
+        })
+          .then((subgroup) => {
+            // create a new membership in the subgroup
+            return cy.create({
+              model: "App\\Membership",
+              attributes: {
+                group_id: subgroup.id,
+              },
+            });
+          })
+          .then((subgroupMembership) => {
+            // create a new leave for the member of the subgroup
+            return cy.create({
+              model: "App\\Leave",
+              attributes: {
+                start_date: dayjs().add(10, "day").format("YYYY-MM-DD"),
+                end_date: dayjs().add(200, "day").format("YYYY-MM-DD"),
+                user_id: subgroupMembership.user_id,
+              },
+            });
+          })
+          .then((leave) => {
+            cy.visit(`/user/${leave.user_id}`);
+
+            cy.get("[data-cy=leavesSection]").should("exist");
+            cy.get("[data-cy=leaveRow]").should("have.length", 1);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
Leaves and Leave Artifacts are now accessible to users who manage a parent group of the leave owner.

- added `$group->getDescendentGroups` which will recursively get any child groups of the given group (and any child groups of that, and so on).
- updated `$user->getManagedGroups()` to return any directly managed groups and any descendent subgroups of managed groups.

Closes #139 

