### PR TITLE
Update api to permit group managers to create a subgroups (stacked on #147)

### DIFF
--- a/app/Policies/GroupPolicy.php
+++ b/app/Policies/GroupPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Constants\Permissions;
 use App\User;
 use App\Group;
 use Illuminate\Auth\Access\HandlesAuthorization;
@@ -61,10 +62,9 @@ class GroupPolicy
         }
     }
 
-    public function create(User $user)
+    public function create(User $user, ?Group $maybeParentGroup)
     {
-        if ($user->can('create groups')) {
-            return true;
-        }
+        return $user->can(Permissions::CREATE_GROUPS)
+            || ($maybeParentGroup && $user->managesGroup($maybeParentGroup));
     }
 }

--- a/app/Policies/LeavePolicy.php
+++ b/app/Policies/LeavePolicy.php
@@ -72,4 +72,9 @@ class LeavePolicy {
         return $currentUser->can(Permissions::VIEW_ANY_LEAVES)
             || $currentUser->managesGroup($group);
     }
+
+    public function createLeavesForGroup(User $currentUser, Group $group): bool {
+        return $currentUser->can(Permissions::EDIT_ANY_LEAVES)
+            || $currentUser->managesGroup($group);
+    }
 }

--- a/tests/Feature/api/group/PostGroupTest.php
+++ b/tests/Feature/api/group/PostGroupTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Constants\Permissions;
+use App\Membership;
+use App\User;
+use App\Group;
+use Database\Seeders\TestDatabaseSeeder;
+use function Pest\Laravel\{postJson, actingAs };
+
+beforeEach(function () {
+    setupMockBandaidApiResponses();
+    $this->seed(TestDatabaseSeeder::class);
+
+    $this->superAdmin = User::where('umndid', 'admin')->first();
+
+    $this->validGroupData = [
+        'groupName' => 'New group',
+        'groupType' => 'department',
+        'parentOrganization' => null,
+    ];
+});
+
+it('returns 401 for unauthenticated user', function () {
+    postJson('/api/group', $this->validGroupData)
+        ->assertStatus(401);
+});
+
+
+it('does not let a default user create a group', function () {
+    actingAs(User::factory()->create())
+        ->postJson('/api/group', $this->validGroupData)
+        ->assertStatus(403);
+});
+
+it('creates a group', function (User $user) {
+    actingAs($user)
+        ->postJson('/api/group', $this->validGroupData)
+        ->assertStatus(200); // TODO: 201
+})->with([
+    'super admin' => fn () => $this->superAdmin,
+    'user with edit groups permission' => fn () => User::factory()->create()->givePermissionTo(Permissions::CREATE_GROUPS),
+]);
+
+it('handles invalid group data', function () {
+    actingAs($this->superAdmin)
+        ->postJson('/api/group', [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['groupName', 'groupType']);
+});
+
+describe('as a group manager', function () {
+    beforeEach(function () {
+        $this->groupManager = User::factory()->create();
+        $this->groupMembership =
+            Membership::factory()->create([
+                'user_id' => $this->groupManager->id,
+                'group_id' => Group::factory()->create()->id,
+                'admin' => true,
+            ]);
+        $this->group = $this->groupMembership->group;
+    });
+
+    it('lets a group manager create a subgroup of a managed group', function () {
+        actingAs($this->groupManager)
+            ->postJson('/api/group', [
+                ...$this->validGroupData,
+                'parentGroupId' => $this->group->id,
+            ])
+            ->assertStatus(200);
+    });
+
+    it('checks that the parentGroupId is valid', function () {
+        actingAs($this->groupManager)
+            ->postJson('/api/group', [
+                ...$this->validGroupData,
+                'parentGroupId' => 999999,
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['parentGroupId']);
+    });
+
+    it('does not let a group manager create a subgroup of a group they do not manage', function () {
+        actingAs($this->groupManager)
+            ->postJson('/api/group', [
+                ...$this->validGroupData,
+                'parentGroupId' => Group::factory()->create()->id,
+            ])
+            ->assertStatus(403);
+    });
+});

--- a/tests/Feature/api/permissions/LeavePermissionsTest.php
+++ b/tests/Feature/api/permissions/LeavePermissionsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use App\{User, Leave, Group, Membership};
+use App\Constants\Permissions;
+use Database\Seeders\TestDatabaseSeeder;
+use function Pest\Laravel\{postJson, getJson, actingAs, deleteJson};
+
+beforeEach(function () {
+    setupMockBandaidApiResponses();
+    $this->seed(TestDatabaseSeeder::class);
+
+    $this->leaveOwner = User::factory()->create();
+    $this->leave = Leave::factory()->create([
+        'user_id' => $this->leaveOwner->id,
+    ]);
+    $this->group = Group::factory()->create();
+    $this->membership = Membership::factory()->create([
+        'user_id' => $this->leaveOwner->id,
+        'group_id' => $this->group->id,
+    ]);
+});
+
+describe('GET /api/permissions/leaves/{leaveId}', function () {
+    it('returns 401 for unauthenticated user for show', function () {
+        getJson("/api/permissions/leaves/{$this->leave->id}")
+            ->assertUnauthorized();
+    });
+
+    it('gets correct leave permissions for user without permission', function () {
+        actingAs(User::factory()->create())
+            ->getJson("/api/permissions/leaves/{$this->leave->id}")
+            ->assertOk()
+            ->assertJson([
+                'view' => false,
+                'update' => false,
+                'delete' => false,
+            ]);
+    });
+
+    it('gets correct leave permissions for user with permission', function () {
+        $managerMembership = Membership::factory()->create([
+            'group_id' => $this->group->id,
+            'admin' => true,
+        ]);
+        $manager = $managerMembership->user;
+
+
+        actingAs($manager)
+            ->getJson("/api/permissions/leaves/{$this->leave->id}")
+            ->assertOk()
+            ->assertJson([
+                'view' => true,
+                'update' => true,
+                'delete' => true,
+            ]);
+    });
+});
+
+
+describe('GET /api/permissions/users/{leaveOwner}/leaves', function () {
+
+    it('returns 401 for unauthed users accessing ', function () {
+        getJson("/api/permissions/users/{$this->leaveOwner->id}/leaves")
+            ->assertUnauthorized();
+    });
+
+    it('returns user leave permissions for authed user without permissions', function () {
+        actingAs(User::factory()->create())
+            ->getJson("/api/permissions/users/{$this->leaveOwner->id}/leaves")
+            ->assertOk()
+            ->assertJson([
+                'viewAny' => false,
+                'create' => false,
+            ]);
+    });
+
+    it('gets correct permissions for user with permissions', function () {
+        actingAs($this->leaveOwner)
+            ->getJson("/api/permissions/users/{$this->leaveOwner->id}/leaves")
+            ->assertOk()
+            ->assertJson([
+                'viewAny' => true,
+                'create' => false,
+            ]);
+
+        $this->leaveOwner->givePermissionTo(Permissions::EDIT_ANY_LEAVES);
+
+        actingAs($this->leaveOwner)
+            ->getJson("/api/permissions/users/{$this->leaveOwner->id}/leaves")
+            ->assertOk()
+            ->assertJson([
+                'viewAny' => true,
+                'create' => true,
+            ]);
+    });
+});
+
+describe('GET /api/permissions/groups/{groupId}/leaves', function () {
+    it('returns 401 for unauthed users accessing ', function () {
+        getJson("/api/permissions/groups/{$this->group->id}/groups")
+            ->assertUnauthorized();
+    });
+
+    it('returns group leave permissions for authed user without permissions', function () {
+        actingAs(User::factory()->create())
+            ->getJson("/api/permissions/groups/{$this->group->id}/leaves")
+            ->assertOk()
+            ->assertJson([
+                'viewAny' => false,
+                'create' => false,
+            ]);
+    });
+
+    it('gets correct permissions for user with permissions', function () {
+        // add a manager to the group
+        $managerMembership = Membership::factory()->create([
+            'group_id' => $this->group->id,
+            'admin' => true,
+        ]);
+        $manager = $managerMembership->user;
+
+        actingAs($manager)
+            ->getJson("/api/permissions/groups/{$this->group->id}/leaves")
+            ->assertOk()
+            ->assertJson([
+                'viewAny' => true,
+                'create' => true,
+            ]);
+    });
+});


### PR DESCRIPTION
As part of #92 , we want group managers to be able to create subgroups of any group they manage.

This updates `POST /api/groups` so that users may submit an optional `parentGroupId` with their POST request. `GroupPolicy::create` is updated so that it checks if parentGroup is managed by the current user.
