### PR TITLE
add ui to permit group managers to create subgroups

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -69,9 +69,9 @@ class GroupController extends Controller
         $this->authorize('create', [Group::class, $parentGroup]);
 
         $newGroup = new \App\Group;
-        
+
         $newGroup->group_title = $request->get("groupName");
-        
+
         if($groupType = $request->get("groupType")) {
             if(isset($groupType["id"])) {
                 $newGroup->group_type_id = $groupType["id"];
@@ -87,19 +87,14 @@ class GroupController extends Controller
             );
             return Response()->json($returnData, 500);
         }
-        
-        
+
         $newGroup->parent_organization_id = $request->get("parentOrganization");
         $newGroup->parent_group_id = $parentGroupId;
         $newGroup->active_group = 1;
         $newGroup->show_unit = false;
         $newGroup->save();
-        $returnData = array(
-            'status' => 'success',
-            'id' => $newGroup->id
-        );
 
-        return Response()->json($returnData);
+        return GroupResource::make($newGroup);
     }
 
     /**

--- a/app/Http/Controllers/GroupPermissionController.php
+++ b/app/Http/Controllers/GroupPermissionController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Auth;
+use App\{Group, Course, Leave};
+
+class GroupPermissionController extends Controller {
+    public function subgroups(Request $request, Group $parentGroup) {
+        abort_if(!$request->user(), 401);
+
+        return [
+            'viewAny' => $request->user()->can('view', [Group::class, $parentGroup]),
+            'create' => $request->user()->can('create', [Group::class, $parentGroup]),
+        ];
+    }
+}

--- a/resources/js/api/api.ts
+++ b/resources/js/api/api.ts
@@ -69,6 +69,16 @@ export async function fetchGroup(groupId: number) {
   return res.data;
 }
 
+export async function createGroup(newGroupData: {
+  groupName: string;
+  parentOrganizationId: T.ParentOrganization["id"];
+  groupType: T.GroupType["label"] | T.GroupType["id"];
+  parentGroupId?: T.Group["id"];
+}) {
+  const res = await axios.post<T.Group>(`/api/group`, newGroupData);
+  return res.data;
+}
+
 export async function createLeaveArtifact(artifact: T.LeaveArtifact) {
   const res = await axios.post<T.LeaveArtifact>(
     `/api/leaves/${artifact.leave_id}/artifacts`,

--- a/resources/js/api/api.ts
+++ b/resources/js/api/api.ts
@@ -185,3 +185,11 @@ export async function getPermissionsForGroupCourses(groupId: number) {
 
   return res.data;
 }
+
+export async function getPermissionsForSubgroupsOf(groupId: T.Group["id"]) {
+  const res = await axios.get<T.ApiResourcePermissions>(
+    `/api/permissions/groups/${groupId}/subgroups`,
+  );
+
+  return res.data;
+}

--- a/resources/js/components/ViewGroup.vue
+++ b/resources/js/components/ViewGroup.vue
@@ -67,6 +67,7 @@
               group.child_groups?.some((g) => g.active_group) ||
               canCreateSubgroup
             "
+            data-cy="child-groups"
           >
             Sub Groups:
             <ul v-if="group.child_groups">
@@ -82,13 +83,20 @@
                 >
               </li>
             </ul>
-            <Button
-              v-if="canCreateSubgroup"
-              variant="tertiary"
-              class="-tw-ml-2"
-            >
-              Add Subgroup
-            </Button>
+            <template v-if="canCreateSubgroup">
+              <Button
+                variant="tertiary"
+                class="-tw-ml-2"
+                @click="isAddingSubgroup = true"
+              >
+                Create Subgroup
+              </Button>
+              <CreateGroup
+                :show="isAddingSubgroup"
+                :parentGroup="group"
+                @close="isAddingSubgroup = false"
+              ></CreateGroup>
+            </template>
           </li>
           <li v-if="canViewGroupLeaves && group.dept_id">
             <router-link :to="`/course-planning/groups/${group.id}`">
@@ -135,6 +143,7 @@ import { useUserStore } from "@/stores/useUserStore";
 import * as api from "@/api";
 import { usePermissionsStore } from "@/stores/usePermissionsStore";
 import Button from "./Button.vue";
+import CreateGroup from "./CreateGroup.vue";
 
 const props = defineProps<{
   group: T.Group;
@@ -150,6 +159,7 @@ const userStore = useUserStore();
 const permissionsStore = usePermissionsStore();
 const canViewGroupLeaves = ref(false);
 const canCreateSubgroup = ref(true);
+const isAddingSubgroup = ref(false);
 
 watch(
   () => props.group,

--- a/resources/js/components/ViewGroup.vue
+++ b/resources/js/components/ViewGroup.vue
@@ -64,8 +64,8 @@
           <li>{{ group.notes }}</li>
           <li
             v-if="
-              group.child_groups?.some((g) => g.active_group) &&
-              $can('view groups')
+              group.child_groups?.some((g) => g.active_group) ||
+              canCreateSubgroup
             "
           >
             Sub Groups:
@@ -82,6 +82,13 @@
                 >
               </li>
             </ul>
+            <Button
+              v-if="canCreateSubgroup"
+              variant="tertiary"
+              class="-tw-ml-2"
+            >
+              Add Subgroup
+            </Button>
           </li>
           <li v-if="canViewGroupLeaves && group.dept_id">
             <router-link :to="`/course-planning/groups/${group.id}`">
@@ -127,6 +134,7 @@ import * as T from "@/types";
 import { useUserStore } from "@/stores/useUserStore";
 import * as api from "@/api";
 import { usePermissionsStore } from "@/stores/usePermissionsStore";
+import Button from "./Button.vue";
 
 const props = defineProps<{
   group: T.Group;
@@ -141,6 +149,7 @@ const allRoles = ref<T.MemberRole[]>([]);
 const userStore = useUserStore();
 const permissionsStore = usePermissionsStore();
 const canViewGroupLeaves = ref(false);
+const canCreateSubgroup = ref(true);
 
 watch(
   () => props.group,

--- a/resources/js/components/ViewGroup.vue
+++ b/resources/js/components/ViewGroup.vue
@@ -158,13 +158,17 @@ const allRoles = ref<T.MemberRole[]>([]);
 const userStore = useUserStore();
 const permissionsStore = usePermissionsStore();
 const canViewGroupLeaves = ref(false);
-const canCreateSubgroup = ref(true);
+const canCreateSubgroup = ref(false);
 const isAddingSubgroup = ref(false);
 
 watch(
   () => props.group,
   async () => {
     canViewGroupLeaves.value = await permissionsStore.canViewAnyLeavesForGroup(
+      props.group.id,
+    );
+
+    canCreateSubgroup.value = await permissionsStore.canCreateSubgroupForGroup(
       props.group.id,
     );
   },

--- a/resources/js/stores/useGroupStore.ts
+++ b/resources/js/stores/useGroupStore.ts
@@ -1,13 +1,20 @@
 import { defineStore } from "pinia";
 import { reactive, toRefs, computed } from "vue";
-import type { Group } from "@/types";
+import type { ChildGroup, Group, GroupType, ParentOrganization } from "@/types";
 import * as api from "@/api";
 
 interface GroupsStoreState {
   groupLookup: Record<Group["id"], Group | undefined>;
 }
 
-export const useGroupStore = defineStore("groups", () => {
+interface NewGroupData {
+  groupName: string;
+  parentOrganizationId: ParentOrganization["id"];
+  groupType: GroupType["label"] | GroupType["id"];
+  parentGroupId?: Group["id"];
+}
+
+export const useGroupStore = defineStore("group", () => {
   const state = reactive<GroupsStoreState>({
     groupLookup: {},
   });
@@ -23,6 +30,42 @@ export const useGroupStore = defineStore("groups", () => {
       const group = await api.fetchGroup(groupId);
       state.groupLookup[groupId] = group;
       return group;
+    },
+
+    // converts a group to a child group
+    // groups currently use `active` to determine if they are active
+    // while child groups use `active_group` for some reason
+    toChildGroup(group: Group): ChildGroup {
+      const { active, ...groupWithoutActive } = group;
+      return {
+        ...groupWithoutActive,
+        active_group: active,
+      };
+    },
+    async createGroup(
+      ...groupData: Parameters<typeof api.createGroup>
+    ): Promise<Group> {
+      const newGroup = await api.createGroup(...groupData);
+
+      // Add the new group to the store
+      state.groupLookup[newGroup.id] = newGroup;
+
+      // if we're not creating a subgroup, we're done
+      if (!newGroup.parent_group_id) {
+        return newGroup;
+      }
+
+      // if this group has a parent group, update the parent group's children
+      const parentGroup =
+        state.groupLookup[newGroup.parent_group_id] ??
+        (await this.fetchGroup(newGroup.parent_group_id));
+
+      parentGroup.child_groups = [
+        ...(parentGroup.child_groups ?? []),
+        this.toChildGroup(newGroup),
+      ];
+
+      return newGroup;
     },
   };
 

--- a/resources/js/stores/usePermissionsStore.ts
+++ b/resources/js/stores/usePermissionsStore.ts
@@ -55,6 +55,12 @@ export const usePermissionsStore = defineStore("permissions", () => {
 
       return groupPlannedCoursePermissions.viewAny;
     },
+
+    async canCreateSubgroupForGroup(groupId: T.Group["id"]): Promise<boolean> {
+      const subgroupPermissions = await api.getPermissionsForSubgroupsOf(groupId);
+
+      return subgroupPermissions.create;
+    }
   };
 
   return {

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\CoursePlanning\GroupCourseController;
 use App\Http\Controllers\ReportController;
 use App\Http\Controllers\LeavePermissionController;
 use App\Http\Controllers\CoursePermissionController;
+use App\Http\Controllers\GroupPermissionController;
 
 Route::impersonate();
 
@@ -95,6 +96,10 @@ Route::group(['prefix' => '/api/', 'middleware' => 'auth'], function () {
         Route::get('users/{leaveOwner}/leaves', [LeavePermissionController::class, 'userLeaves']);
         Route::get('groups/{group}/leaves', [LeavePermissionController::class, 'groupLeaves']);
         Route::get('groups/{group}/courses', [CoursePermissionController::class, 'groupCourses']);
+        Route::get(
+            'groups/{group}/subgroups',
+            [GroupPermissionController::class, 'subgroups']
+        );
     });
 
     Route::prefix('course-planning')->group(function () {

--- a/tests/Feature/api/group/PostGroupTest.php
+++ b/tests/Feature/api/group/PostGroupTest.php
@@ -5,7 +5,7 @@ use App\Membership;
 use App\User;
 use App\Group;
 use Database\Seeders\TestDatabaseSeeder;
-use function Pest\Laravel\{postJson, actingAs };
+use function Pest\Laravel\{postJson, actingAs};
 
 beforeEach(function () {
     setupMockBandaidApiResponses();
@@ -35,7 +35,7 @@ it('does not let a default user create a group', function () {
 it('creates a group', function (User $user) {
     actingAs($user)
         ->postJson('/api/group', $this->validGroupData)
-        ->assertStatus(200); // TODO: 201
+        ->assertStatus(201);
 })->with([
     'super admin' => fn () => $this->superAdmin,
     'user with edit groups permission' => fn () => User::factory()->create()->givePermissionTo(Permissions::CREATE_GROUPS),
@@ -66,7 +66,7 @@ describe('as a group manager', function () {
                 ...$this->validGroupData,
                 'parentGroupId' => $this->group->id,
             ])
-            ->assertStatus(200);
+            ->assertStatus(201);
     });
 
     it('checks that the parentGroupId is valid', function () {

--- a/tests/Feature/api/permissions/SubgroupPermissionsTest.php
+++ b/tests/Feature/api/permissions/SubgroupPermissionsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\{User, Leave, Group, Membership};
+use App\Constants\Permissions;
+use Database\Seeders\TestDatabaseSeeder;
+use function Pest\Laravel\{postJson, getJson, actingAs, deleteJson};
+
+beforeEach(function () {
+    setupMockBandaidApiResponses();
+    $this->seed(TestDatabaseSeeder::class);
+
+    $this->group = Group::factory()->create();
+    $this->membership = Membership::factory()->create([
+        'group_id' => $this->group->id,
+    ]);
+
+    $this->superAdmin = User::where('umndid', 'admin')->first();
+    $this->groupManager = User::factory()->create();
+    $this->groupMembership = Membership::factory()->create([
+        'user_id' => $this->groupManager->id,
+        'group_id' => $this->group->id,
+        'admin' => true,
+    ]);
+});
+
+describe("/api/permissions/groups/{groupId}/subgroups", function () {
+    it('requires authentication', function () {
+        getJson("/api/permissions/groups/{$this->group->id}/subgroups")
+            ->assertUnauthorized();
+    });
+
+    it('shows a default user can view subgroups but not create', function () {
+        actingAs(User::factory()->create())
+            ->getJson("/api/permissions/groups/{$this->group->id}/subgroups")
+            ->assertOk()
+            ->assertJson([
+                'viewAny' => true,
+                'create' => false,
+            ]);
+    });
+
+    it('permits users with proper permissions to create subgroups', function (User $user) {
+        actingAs($user)
+            ->getJson("/api/permissions/groups/{$this->group->id}/subgroups")
+            ->assertOk()
+            ->assertJson([
+                'viewAny' => true,
+                'create' => true,
+            ]);
+    })->with([
+        'super admin' => fn () => $this->superAdmin,
+        'user with create groups permissions' => fn () => User::factory()->create()->givePermissionTo(Permissions::CREATE_GROUPS),
+        'group manager' => fn () => $this->groupManager,
+    ]);
+});

--- a/tests/cypress/integration/groupCreation.test.ts
+++ b/tests/cypress/integration/groupCreation.test.ts
@@ -118,6 +118,13 @@ describe("Groups UI", () => {
       cy.login({ id: groupManagerId });
       cy.visit(`/group/${groupId}`);
       cy.contains("Create Subgroup").click();
+      cy.get("#groupName").type("Test Subgroup");
+      cy.get("#groupTypes input").type("Working Group{enter}");
+      cy.contains("Create Group").click();
+
+      cy.get('[data-cy=child-groups]').contains("Test Subgroup").click();
+
+      cy.contains("Working Group");
     });
   });
 });

--- a/tests/cypress/integration/groupCreation.test.ts
+++ b/tests/cypress/integration/groupCreation.test.ts
@@ -98,4 +98,26 @@ describe("Groups UI", () => {
       );
     });
   });
+
+  context("as a group manager", () => {
+    let groupId;
+    let groupManagerId;
+    beforeEach(() => {
+      cy.create("App\\Membership").then((membership) => {
+        groupId = membership.group_id;
+        groupManagerId = membership.user_id;
+
+        cy.promoteUserToGroupManager({
+          userId: groupManagerId,
+          groupId,
+        });
+      });
+    });
+
+    it.only("creates a new subgroup for their group", () => {
+      cy.login({ id: groupManagerId });
+      cy.visit(`/group/${groupId}`);
+      cy.contains("Create Subgroup").click();
+    });
+  });
 });


### PR DESCRIPTION
This:
- adds functionality for group managers to create subgroups on the GroupsPage (Note: This PR is focused on functionality. A forthcoming PR will update the layout.)
- adds endpoint for checking if currentUser has permissions to update subgroups
- move create group functionality to the GroupStore. When a new group is created, the store is updated. Additionally, the parent's child groups are updated.
- changes the `POST /api/group` to return the new group. Previously, it returned the id and a status message.

Closes #92 


