### PR TITLE
Permit BlueSheet manages to edit subgroups

### DIFF
--- a/app/Group.php
+++ b/app/Group.php
@@ -90,17 +90,6 @@ class Group extends Model implements AuditableContract {
         return $this->activeMembers->pluck('user');
     }
 
-    public function userCanEdit($user) {
-        $activeMembers = $this->activeMembers;
-
-        foreach ($activeMembers as $member) {
-            if ($member->user && $member->user->is($user) && $member->admin) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     public function getHashAttribute() {
         return substr(sha1($this->id . config("app.key")), 0, 10);
     }

--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -18,7 +18,10 @@ class Group extends JsonResource
 
         return [
             "id"=>$this->id,
-            "user_can_edit"=>Auth::user()?$this->userCanEdit(Auth::user()):false,
+            "canCurrentUser" => [
+                "update" => $request->user()->can('update', $this->resource),
+                "delete" => $request->user()->can('delete', $this->resource),
+            ],
             "group_title"=>$this->group_title,
             "abbreviation"=>$this->abbreviation,
             "dept_id"=>$this->dept_id,
@@ -37,7 +40,8 @@ class Group extends JsonResource
             "notes"=>$this->notes,
             "include_child_groups"=>$this->include_child_groups,
             "members"=>$this->relationLoaded('members')?($this->members->map(function($membership) {
-                return new MembershipResource($membership);})):[]
+                return new MembershipResource($membership);})):[],
+
         ];
     }
 }

--- a/app/Http/Resources/Group.php
+++ b/app/Http/Resources/Group.php
@@ -40,8 +40,7 @@ class Group extends JsonResource
             "notes"=>$this->notes,
             "include_child_groups"=>$this->include_child_groups,
             "members"=>$this->relationLoaded('members')?($this->members->map(function($membership) {
-                return new MembershipResource($membership);})):[],
-
+                return new MembershipResource($membership);})):[]
         ];
     }
 }

--- a/app/Policies/GroupPolicy.php
+++ b/app/Policies/GroupPolicy.php
@@ -39,16 +39,10 @@ class GroupPolicy
         return $group->activeUsers()->pluck("id")->contains($user->id);
     }
 
-
     public function update(User $user, Group $group)
     {
-        if($group->userCanEdit($user)) {
-            return true;
-        }
-
-        if ($user->can('edit groups')) {
-            return true;
-        }
+        return $user->can(Permissions::EDIT_GROUPS)
+            || $user->managesGroup($group);
     }
 
     public function delete(User $user, Group $group)

--- a/app/Policies/GroupPolicy.php
+++ b/app/Policies/GroupPolicy.php
@@ -11,16 +11,6 @@ class GroupPolicy
 {
     use HandlesAuthorization;
 
-    /**
-     * Create a new policy instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
     public function view(?User $user, Group $group)
     {
         // visitors cannot view groups
@@ -28,15 +18,8 @@ class GroupPolicy
             return false;
         }
 
-        // admin overrides published status
-        if ($user->can('view groups')) {
-            return true;
-        }
-
-        // TODO: validate codes?
-
-        // authors can view their own unpublished posts
-        return $group->activeUsers()->pluck("id")->contains($user->id);
+        return $user->can(Permissions::VIEW_GROUPS)
+            || $user->isMemberOf($group);
     }
 
     public function update(User $user, Group $group)
@@ -47,13 +30,7 @@ class GroupPolicy
 
     public function delete(User $user, Group $group)
     {
-        if($group->userCanEdit($user)) {
-            return true;
-        }
-
-        if ($user->can('edit groups')) {
-            return true;
-        }
+        return $this->update($user, $group);
     }
 
     public function create(User $user, ?Group $maybeParentGroup)

--- a/app/User.php
+++ b/app/User.php
@@ -119,4 +119,8 @@ class User extends Authenticatable implements Auditable {
     public function managesGroup(Group $group): bool {
         return $this->getManagedGroups()->pluck('id')->contains($group->id);
     }
+
+    public function isMemberOf(Group $group): bool {
+        return $this->groups->pluck('id')->contains($group->id);
+    }
 }

--- a/resources/js/components/ViewGroup.vue
+++ b/resources/js/components/ViewGroup.vue
@@ -18,7 +18,7 @@
             Favorite
           </button>
           <button
-            v-if="$can('edit groups') || group.user_can_edit"
+            v-if="group.canCurrentUser.update"
             class="btn btn-outline-primary"
             @click="$emit('update:isEditing', true)"
           >

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -112,7 +112,7 @@ export interface ParentOrganization {
 
 export interface BaseGroup {
   id: number;
-  user_can_edit: boolean; // current user can edit
+  canCurrentUser: ApiResourceItemPermissions;
   group_title: string | null; // "Anthropology";
   abbreviation: string | null; // "ANTH";
   group_type_id?: number;

--- a/tests/Feature/api/group/PatchGroupTest.php
+++ b/tests/Feature/api/group/PatchGroupTest.php
@@ -98,7 +98,7 @@ describe('PUT /api/group/{groupId}', function () {
     })->with([
         'super admin' => fn () => $this->superAdmin,
         'user with edit groups permission' => fn () => User::factory()->create()->givePermissionTo(Permissions::EDIT_GROUPS),
-        // 'group manager' => fn () => $this->groupManager,
+        'group manager' => fn () => $this->groupManager,
     ]);
 
 });

--- a/tests/Feature/api/group/PatchGroupTest.php
+++ b/tests/Feature/api/group/PatchGroupTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Constants\Permissions;
+use App\Membership;
+use App\User;
+use App\Group;
+use Database\Seeders\TestDatabaseSeeder;
+use function Pest\Laravel\{patchJson, actingAs};
+
+function createGroupAndLoadRelationships($attrs = null) {
+    $group = Group::factory()
+        ->create($attrs)
+        ->load([
+            'artifacts',
+            'groupType',
+            'members',
+            'members.role'
+        ]);
+
+    return $group;
+}
+
+beforeEach(function () {
+    setupMockBandaidApiResponses();
+    $this->seed(TestDatabaseSeeder::class);
+
+    $this->superAdmin = User::where('umndid', 'admin')->first();
+
+    $this->group = createGroupAndLoadRelationships();
+
+    $this->groupManager = User::factory()->create();
+    $this->groupMembership =
+        Membership::factory()->create([
+            'user_id' => $this->groupManager->id,
+            'group_id' => $this->group->id,
+            'admin' => true,
+        ]);
+});
+
+describe('PUT /api/group/{groupId}', function () {
+    it('rejects unauthenticated user', function () {
+        patchJson("/api/group/{$this->group->id}", [
+            'group_title' => 'New group name',
+        ])
+            ->assertStatus(401);
+    });
+
+    it('does not let a default user update a group', function () {
+        actingAs(User::factory()->create())
+            ->patchJson("/api/group/{$this->group->id}", [
+                'group_title' => 'New group name',
+            ])
+            ->assertStatus(403);
+    });
+
+    it('updates a group', function (User $user) {
+        actingAs($user)
+            ->patchJson("/api/group/{$this->group->id}", [
+                ...$this->group->toArray(),
+                'group_title' => 'New group name',
+            ])
+            ->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+            ]);
+
+        $this->assertDatabaseHas('groups', [
+            'id' => $this->group->id,
+            'group_title' => 'New group name',
+        ]);
+
+    })->with([
+        'super admin' => fn () => $this->superAdmin,
+        'user with edit groups permission' => fn () => User::factory()->create()->givePermissionTo(Permissions::EDIT_GROUPS),
+        'group manager' => fn () => $this->groupManager,
+    ]);
+
+    it('updates a subgroup', function (User $user) {
+        $subgroup = createGroupAndLoadRelationships([
+            'parent_group_id' => $this->group->id,
+        ]);
+
+        actingAs($user)
+            ->patchJson("/api/group/{$subgroup->id}", [
+                ...$subgroup->toArray(),
+                'group_title' => 'New subgroup name',
+            ])
+            ->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+            ]);
+
+        $this->assertDatabaseHas('groups', [
+            'id' => $subgroup->id,
+            'group_title' => 'New subgroup name',
+        ]);
+
+    })->with([
+        'super admin' => fn () => $this->superAdmin,
+        'user with edit groups permission' => fn () => User::factory()->create()->givePermissionTo(Permissions::EDIT_GROUPS),
+        // 'group manager' => fn () => $this->groupManager,
+    ]);
+
+});


### PR DESCRIPTION
- changes the GroupPolicy `update` and `delete` methods to check if a $user manages a group or subgroup
- updates the `GroupResource` to return permissions akin to other resources. These permission checks defer to the GroupPolicy.
  ```json5
   canCurrentUser: { update: true, delete: true },
  ```
  This replaces the previous `user_can_edit` property property.
- updates the frontend to use `group.canCurrentUser.update` to determine if edit button should be displayed
- simplifies other GroupPolicy
- removes the old `Group::userCanEdit` method as policy checks are now done directly.
- adds test for editing groups via api

on dev for testing