### PR TITLE
fix: don't show bluesheet manager check column on RolesPage

### DIFF
--- a/resources/js/components/MemberList.vue
+++ b/resources/js/components/MemberList.vue
@@ -96,7 +96,10 @@
         ></i>
         <i v-else class="searchIcon fa fa-close"></i>
       </td>
-      <td v-if="editing || $can('edit groups')" class="tw-text-center">
+      <td
+        v-if="viewType === 'group' && ($can('edit groups') || editing)"
+        class="tw-text-center"
+      >
         <input
           v-if="editing"
           v-model="member.admin"
@@ -133,7 +136,7 @@ export default {
     "includePreviousMembers",
     "roles",
     "show_unit",
-    "viewType",
+    "viewType", // "group" or "role"
   ],
   emits: ["remove", "update:roles"],
   methods: {

--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -179,7 +179,14 @@
               @sort="sort"
             />
           </th>
-          <th v-if="!showGantt && (editing || $can('edit groups'))" scope="col">
+          <th
+            v-if="
+              !showGantt &&
+              viewType === 'group' &&
+              (editing || $can('edit groups'))
+            "
+            scope="col"
+          >
             BlueSheet Manager
           </th>
           <th v-if="editing && !showGantt" scope="col">
@@ -329,7 +336,7 @@ export default defineComponent({
       required: true,
     },
     viewType: {
-      type: String,
+      type: String as PropType<"group" | "role">,
       required: true,
     },
     downloadTitle: {


### PR DESCRIPTION
This fixes an issue where users with 'edit group' permissions would see the BlueSheet manager column on the `RolesPage` causing some weird formatting.

Before:
![ScreenShot 2024-04-10 at 14 06 06@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/15bbfb65-b1cd-4492-8b08-eeceb256b05a)

This is because `RolesPage` and `GroupPage` share a `MemberList` component that shows different things depending on the `viewType` prop. 

Render logic is updated to check viewType.

After:
![ScreenShot 2024-04-10 at 14 07 19@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/a615bf19-4fc6-4684-a199-0fcfe1cf308a)


on dev for testing