### PR TITLE
Fix weird gantt chart header formatting

### DIFF
--- a/resources/js/components/Gantt.vue
+++ b/resources/js/components/Gantt.vue
@@ -1,49 +1,73 @@
 <template>
-  <tbody>
-    <tr>
-      <th v-if="filterList" width="5%"></th>
-      <th width="20%"></th>
-      <th colspan="6" width="80%">
-        <span>{{ minDatePretty }}</span>
-        <span class="float-right">
-          {{ maxDatePretty }}
-        </span>
-      </th>
-    </tr>
-    <GanttRow
-      v-for="member in members"
-      :key="member.id"
-      :show_unit="show_unit"
-      :member="member"
-      :mindate="mindate"
-      :maxdate="maxdate"
-      :filterList="filterList"
-      @update:member="(updatedMember) => $emit('update:member', updatedMember)"
-    />
+  <table class="table">
+    <thead>
+      <tr>
+        <th v-if="filterList" scope="col" width="5%">Filter</th>
+        <th scope="col">
+          <SortableLink
+            sortLabel="Name"
+            sortElement="user.surname"
+            :currentSort="currentSort"
+            :currentSortDir="currentSortDir"
+            @sort="$emit('sort', $event)"
+          />
+        </th>
+        <th colspan="6" width="80%">
+          <span>{{ minDatePretty }}</span>
+          <span class="float-right">
+            {{ maxDatePretty }}
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <GanttRow
+        v-for="member in members"
+        :key="member.id"
+        :show_unit="show_unit"
+        :member="member"
+        :mindate="mindate"
+        :maxdate="maxdate"
+        :filterList="filterList"
+        @update:member="
+          (updatedMember) => $emit('update:member', updatedMember)
+        "
+      />
 
-    <tr>
-      <th v-if="filterList" width="5%"></th>
-      <th width="20%"></th>
-      <th colspan="6" width="80%">
-        <span>{{ minDatePretty }}</span>
-        <span class="float-right">
-          {{ maxDatePretty }}
-        </span>
-      </th>
-    </tr>
-  </tbody>
+      <tr>
+        <th v-if="filterList" width="5%"></th>
+        <th width="20%"></th>
+        <th colspan="6" width="80%">
+          <span>{{ minDatePretty }}</span>
+          <span class="float-right">
+            {{ maxDatePretty }}
+          </span>
+        </th>
+      </tr>
+    </tbody>
+  </table>
 </template>
 
 <script lang="ts">
 import GanttRow from "./GanttRow.vue";
+import SortableLink from "./SortableLink.vue";
 import { dayjs } from "@/utils";
 
 export default {
   components: {
+    SortableLink,
     GanttRow,
   },
-  props: ["members", "mindate", "maxdate", "show_unit", "filterList"],
-  emits: ["update:member"],
+  props: [
+    "members",
+    "mindate",
+    "maxdate",
+    "show_unit",
+    "filterList",
+    "currentSort",
+    "currentSortDir",
+  ],
+  emits: ["update:member", "sort"],
   data() {
     return {};
   },

--- a/resources/js/components/MemberList.vue
+++ b/resources/js/components/MemberList.vue
@@ -1,120 +1,211 @@
 <template>
-  <tbody>
-    <tr v-for="member in filteredList" :key="member.id">
-      <td v-if="filterList">
-        <input v-model="member.filtered" type="checkbox" />
-      </td>
+  <table class="table">
+    <thead>
+      <tr>
+        <th v-if="filterList" scope="col" width="5%">Filter</th>
+        <th scope="col">
+          <SortableLink
+            sortLabel="Name"
+            sortElement="user.surname"
+            :currentSort="currentSort"
+            :currentSortDir="currentSortDir"
+            @sort="$emit('sort', $event)"
+          />
+        </th>
+        <th v-if="show_unit && viewType == 'group'" scope="col">
+          <SortableLink
+            sortLabel="Unit"
+            sortElement="user.ou"
+            :currentSort="currentSort"
+            :currentSortDir="currentSortDir"
+            @sort="$emit('sort', $event)"
+          />
+        </th>
+        <th v-if="viewType == 'group'" scope="col">
+          <SortableLink
+            sortLabel="Role"
+            sortElement="role.label"
+            :currentSort="currentSort"
+            :currentSortDir="currentSortDir"
+            @sort="$emit('sort', $event)"
+          />
+        </th>
 
-      <td>
-        <router-link
-          v-if="member.user.id && $can('view users')"
-          :to="{ name: 'user', params: { userId: member.user.id } }"
-        >
-          {{ member.user.surname }}, {{ member.user.givenname }}
-        </router-link>
-        <span v-if="!member.user.id || !$can('view users')"
-          >{{ member.user.surname }}, {{ member.user.givenname }}</span
-        >
-      </td>
-      <td v-if="show_unit && viewType == 'group'">{{ member.user.ou }}</td>
+        <th v-if="viewType == 'role'" scope="col">
+          <SortableLink
+            sortLabel="Group"
+            sortElement="group.group_title"
+            :currentSort="currentSort"
+            :currentSortDir="currentSortDir"
+            @sort="$emit('sort', $event)"
+          />
+        </th>
 
-      <template v-if="viewType == 'group'">
-        <td v-if="!editing">
-          {{ member.role.label }}
-          <span v-if="member.child_group_title"
-            >({{ member.child_group_title }})</span
+        <th scope="col">
+          <SortableLink
+            sortLabel="Notes"
+            sortElement="notes"
+            :currentSort="currentSort"
+            :currentSortDir="currentSortDir"
+            @sort="$emit('sort', $event)"
+          />
+        </th>
+
+        <th scope="col">
+          <SortableLink
+            sortLabel="From"
+            sortElement="start_date"
+            :currentSort="currentSort"
+            :currentSortDir="currentSortDir"
+            @sort="$emit('sort', $event)"
+          />
+        </th>
+
+        <th v-if="includePreviousMembers || editing" scope="col">
+          <SortableLink
+            sortLabel="Until"
+            sortElement="end_date"
+            :currentSort="currentSort"
+            :currentSortDir="currentSortDir"
+            @sort="$emit('sort', $event)"
+          />
+        </th>
+        <th v-if="!editing && viewType == 'group'" scope="col" width="11%">
+          <SortableLink
+            sortLabel="Official Role"
+            sortElement="role.official_group_type"
+            :currentSort="currentSort"
+            :currentSortDir="currentSortDir"
+          />
+        </th>
+        <th
+          v-if="viewType === 'group' && (editing || $can('edit groups'))"
+          scope="col"
+        >
+          BlueSheet Manager
+        </th>
+        <th v-if="editing" scope="col">End Active Membership</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="member in filteredList" :key="member.id">
+        <td v-if="filterList">
+          <input v-model="member.filtered" type="checkbox" />
+        </td>
+
+        <td>
+          <router-link
+            v-if="member.user.id && $can('view users')"
+            :to="{ name: 'user', params: { userId: member.user.id } }"
+          >
+            {{ member.user.surname }}, {{ member.user.givenname }}
+          </router-link>
+          <span v-if="!member.user.id || !$can('view users')"
+            >{{ member.user.surname }}, {{ member.user.givenname }}</span
           >
         </td>
+        <td v-if="show_unit && viewType == 'group'">{{ member.user.ou }}</td>
+
+        <template v-if="viewType == 'group'">
+          <td v-if="!editing">
+            {{ member.role.label }}
+            <span v-if="member.child_group_title"
+              >({{ member.child_group_title }})</span
+            >
+          </td>
+          <td v-if="editing">
+            <ComboBox
+              v-if="roles"
+              v-model="member.role"
+              :options="roles"
+              :canAddNewOption="true"
+              @addNewOption="
+                (newRole) => $emit('update:roles', [...roles, newRole])
+              "
+            />
+          </td>
+        </template>
+
+        <td v-if="viewType == 'role'">
+          <router-link
+            v-if="member.group.id && $can('edit users')"
+            :to="{ name: 'group', params: { groupId: member.group.id } }"
+          >
+            <GroupTitle :group="member.group" />
+          </router-link>
+          <span v-if="!member.group.id || !$can('edit users')">{{
+            member.group.group_title
+          }}</span>
+        </td>
+
+        <td v-if="!editing">{{ member.notes }}</td>
         <td v-if="editing">
-          <ComboBox
-            v-if="roles"
-            v-model="member.role"
-            :options="roles"
-            :canAddNewOption="true"
-            @addNewOption="
-              (newRole) => $emit('update:roles', [...roles, newRole])
+          <input v-model="member.notes" class="form-control" />
+        </td>
+
+        <td v-if="!editing">
+          {{
+            member.start_date
+              ? dayjs(member.start_date).format("YYYY, MMM Do")
+              : ""
+          }}
+        </td>
+        <td v-if="editing">
+          <input
+            type="date"
+            class="form-control"
+            :value="member.start_date"
+            @blur="
+              member.start_date = ($event.target as HTMLInputElement).value
             "
           />
         </td>
-      </template>
 
-      <td v-if="viewType == 'role'">
-        <router-link
-          v-if="member.group.id && $can('edit users')"
-          :to="{ name: 'group', params: { groupId: member.group.id } }"
+        <td v-if="includePreviousMembers && !editing">
+          <span v-if="member.end_date">{{
+            dayjs(member.end_date).format("YYYY, MMM Do")
+          }}</span>
+        </td>
+        <td v-if="editing">
+          <input
+            type="date"
+            class="form-control"
+            :value="member.end_date"
+            @blur="member.end_date = ($event.target as HTMLInputElement).value"
+          />
+        </td>
+
+        <td v-if="!editing">
+          <i
+            v-if="
+              viewType == 'group' &&
+              member.role.official_group_type &&
+              member.role.official_group_type.length > 0
+            "
+            class="fa fa-check"
+          ></i>
+          <i v-else class="searchIcon fa fa-close"></i>
+        </td>
+        <td
+          v-if="viewType === 'group' && ($can('edit groups') || editing)"
+          class="tw-text-center"
         >
-          <GroupTitle :group="member.group" />
-        </router-link>
-        <span v-if="!member.group.id || !$can('edit users')">{{
-          member.group.group_title
-        }}</span>
-      </td>
-
-      <td v-if="!editing">{{ member.notes }}</td>
-      <td v-if="editing">
-        <input v-model="member.notes" class="form-control" />
-      </td>
-
-      <td v-if="!editing">
-        {{
-          member.start_date
-            ? dayjs(member.start_date).format("YYYY, MMM Do")
-            : ""
-        }}
-      </td>
-      <td v-if="editing">
-        <input
-          type="date"
-          class="form-control"
-          :value="member.start_date"
-          @blur="member.start_date = ($event.target as HTMLInputElement).value"
-        />
-      </td>
-
-      <td v-if="includePreviousMembers && !editing">
-        <span v-if="member.end_date">{{
-          dayjs(member.end_date).format("YYYY, MMM Do")
-        }}</span>
-      </td>
-      <td v-if="editing">
-        <input
-          type="date"
-          class="form-control"
-          :value="member.end_date"
-          @blur="member.end_date = ($event.target as HTMLInputElement).value"
-        />
-      </td>
-
-      <td v-if="!editing">
-        <i
-          v-if="
-            viewType == 'group' &&
-            member.role.official_group_type &&
-            member.role.official_group_type.length > 0
-          "
-          class="fa fa-check"
-        ></i>
-        <i v-else class="searchIcon fa fa-close"></i>
-      </td>
-      <td
-        v-if="viewType === 'group' && ($can('edit groups') || editing)"
-        class="tw-text-center"
-      >
-        <input
-          v-if="editing"
-          v-model="member.admin"
-          class="form-check-input"
-          type="checkbox"
-        />
-        <CheckIcon v-else-if="member.admin" />
-      </td>
-      <td v-if="editing">
-        <button class="btn btn-danger" @click="$emit('remove', member)">
-          <i class="fas fa-user-minus"></i>
-        </button>
-      </td>
-    </tr>
-  </tbody>
+          <input
+            v-if="editing"
+            v-model="member.admin"
+            class="form-check-input"
+            type="checkbox"
+          />
+          <CheckIcon v-else-if="member.admin" />
+        </td>
+        <td v-if="editing">
+          <button class="btn btn-danger" @click="$emit('remove', member)">
+            <i class="fas fa-user-minus"></i>
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </template>
 
 <script lang="ts">
@@ -122,12 +213,14 @@ import GroupTitle from "./GroupTitle.vue";
 import { dayjs, $can } from "@/utils";
 import ComboBox from "./ComboBox.vue";
 import { CheckIcon } from "@/icons";
+import SortableLink from "./SortableLink.vue";
 
 export default {
   components: {
     GroupTitle,
     ComboBox,
     CheckIcon,
+    SortableLink,
   },
   props: [
     "editing",
@@ -137,8 +230,10 @@ export default {
     "roles",
     "show_unit",
     "viewType", // "group" or "role"
+    "currentSort",
+    "currentSortDir",
   ],
-  emits: ["remove", "update:roles"],
+  emits: ["remove", "update:roles", "sort"],
   methods: {
     dayjs,
     $can,

--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -92,131 +92,34 @@
       </div>
     </div>
 
-    <table class="table">
-      <thead>
-        <tr>
-          <th v-if="filterList" scope="col" width="5%">Filter</th>
-          <th scope="col">
-            <SortableLink
-              sortLabel="Name"
-              sortElement="user.surname"
-              :currentSort="currentSort"
-              :currentSortDir="currentSortDir"
-              @sort="sort"
-            />
-          </th>
-          <th v-if="show_unit && !showGantt && viewType == 'group'" scope="col">
-            <SortableLink
-              sortLabel="Unit"
-              sortElement="user.ou"
-              :currentSort="currentSort"
-              :currentSortDir="currentSortDir"
-              @sort="sort"
-            />
-          </th>
-          <th v-if="!showGantt && viewType == 'group'" scope="col">
-            <SortableLink
-              sortLabel="Role"
-              sortElement="role.label"
-              :currentSort="currentSort"
-              :currentSortDir="currentSortDir"
-              @sort="sort"
-            />
-          </th>
-
-          <th v-if="!showGantt && viewType == 'role'" scope="col">
-            <SortableLink
-              sortLabel="Group"
-              sortElement="group.group_title"
-              :currentSort="currentSort"
-              :currentSortDir="currentSortDir"
-              @sort="sort"
-            />
-          </th>
-
-          <th v-if="!showGantt" scope="col">
-            <SortableLink
-              sortLabel="Notes"
-              sortElement="notes"
-              :currentSort="currentSort"
-              :currentSortDir="currentSortDir"
-              @sort="sort"
-            />
-          </th>
-
-          <th v-if="!showGantt" scope="col">
-            <SortableLink
-              sortLabel="From"
-              sortElement="start_date"
-              :currentSort="currentSort"
-              :currentSortDir="currentSortDir"
-              @sort="sort"
-            />
-          </th>
-
-          <th
-            v-if="!showGantt && (includePreviousMembers || editing)"
-            scope="col"
-          >
-            <SortableLink
-              sortLabel="Until"
-              sortElement="end_date"
-              :currentSort="currentSort"
-              :currentSortDir="currentSortDir"
-              @sort="sort"
-            />
-          </th>
-          <th
-            v-if="!showGantt && !editing && viewType == 'group'"
-            scope="col"
-            width="11%"
-          >
-            <SortableLink
-              sortLabel="Official Role"
-              sortElement="role.official_group_type"
-              :currentSort="currentSort"
-              :currentSortDir="currentSortDir"
-              @sort="sort"
-            />
-          </th>
-          <th
-            v-if="
-              !showGantt &&
-              viewType === 'group' &&
-              (editing || $can('edit groups'))
-            "
-            scope="col"
-          >
-            BlueSheet Manager
-          </th>
-          <th v-if="editing && !showGantt" scope="col">
-            End Active Membership
-          </th>
-        </tr>
-      </thead>
-      <MemberList
-        v-if="!showGantt"
-        :show_unit="show_unit"
-        :roles="roles"
-        :editing="editing"
-        :filteredList="filteredList"
-        :filterList="filterList"
-        :includePreviousMembers="includePreviousMembers"
-        :viewType="viewType"
-        @remove="removeMember"
-        @update:roles="(val) => $emit('update:roles', val)"
-      >
-      </MemberList>
-      <Gantt
-        v-if="showGantt"
-        :members="filteredList"
-        :filterList="filterList"
-        :mindate="lowestValue"
-        :maxdate="highestValue"
-        :show_unit="show_unit"
-        @update:member="(val) => $emit('update:members', val)"
-      ></Gantt>
-    </table>
+    <MemberList
+      v-if="!showGantt"
+      :show_unit="show_unit"
+      :roles="roles"
+      :editing="editing"
+      :filteredList="filteredList"
+      :filterList="filterList"
+      :includePreviousMembers="includePreviousMembers"
+      :viewType="viewType"
+      :currentSort="currentSort"
+      :currentSortDir="currentSortDir"
+      @remove="removeMember"
+      @update:roles="(val) => $emit('update:roles', val)"
+      @sort="sort"
+    >
+    </MemberList>
+    <Gantt
+      v-if="showGantt"
+      :members="filteredList"
+      :filterList="filterList"
+      :mindate="lowestValue"
+      :maxdate="highestValue"
+      :currentSort="currentSort"
+      :currentSortDir="currentSortDir"
+      :show_unit="show_unit"
+      @update:member="(val) => $emit('update:members', val)"
+      @sort="sort"
+    ></Gantt>
     <div
       v-if="officialRoles.length > 0 && unfilledRoles.length > 0 && editing"
       class="card mt-3 mb-3 col-sm-6"
@@ -277,7 +180,6 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
-import SortableLink from "./SortableLink.vue";
 import DownloadCSV from "./DownloadCSV.vue";
 import MemberList from "./MemberList.vue";
 import Gantt from "./Gantt.vue";
@@ -303,7 +205,6 @@ interface MembershipWithMaybeChildGroupTitle extends Membership {
 
 export default defineComponent({
   components: {
-    SortableLink,
     DownloadCSV,
     MemberList,
     Gantt,

--- a/resources/js/components/SortableLink.vue
+++ b/resources/js/components/SortableLink.vue
@@ -1,14 +1,15 @@
 <template>
-  <span class="sortableLink" @click="$emit('sort', sortElement)"
-    >{{ sortLabel }}
+  <button class="sortableLink" @click="$emit('sort', sortElement)">
+    {{ sortLabel }}
     <i
       class="fas"
       :class="{
         'fa-sort-alpha-up': currentSortDir == 'desc' && isCurrentSort,
         'fa-sort-alpha-down': currentSortDir == 'asc' && isCurrentSort,
+        'fa-sort tw-text-neutral-300': !isCurrentSort,
       }"
     ></i>
-  </span>
+  </button>
 </template>
 
 <script setup lang="ts">
@@ -37,5 +38,15 @@ const isCurrentSort = computed(() => {
 .sortableLink {
   cursor: pointer;
   text-transform: capitalize;
+  border: none;
+  background-color: transparent;
+  color: inherit;
+  padding: 0;
+  margin: 0;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: bold;
 }
 </style>


### PR DESCRIPTION
This fixes the gantt chart table header rendering.

BEFORE: Name and dates appear as separate broken rows
<img src="https://github.com/UMN-LATIS/bluesheet/assets/980170/48b9c983-b378-4bf9-b9a0-caf716946539" width="400" />

AFTER: Single row
<img src="https://github.com/UMN-LATIS/bluesheet/assets/980170/c5f7cfe1-d40a-488d-8401-9149c969c38d" width="400" />

## Details 
Previously, the headers were in a different component as table body. This made it easy for a header/body column mismatch. 

This turns the `MemberList` and `Gantt` components into full tables, including their column headers. Sorting props are passed down, and then when a SortableLink is clicked, a sort event is emitted so that both components keep the correct order.

Sortable Link is changed to a button element for accessibility. (Previously it was a `<span>`).

On dev for testing.

