### PR TITLE
Fix truncated roles in role combobox dropdown

### DIFF
--- a/resources/js/components/ComboBox.vue
+++ b/resources/js/components/ComboBox.vue
@@ -66,18 +66,13 @@
               ]"
             >
               <div class="tw-flex tw-flex-col">
-                <div
-                  :class="[
-                    'tw-block tw-truncate',
-                    selected && 'tw-font-semibold',
-                  ]"
-                >
+                <div :class="['tw-block', selected && 'tw-font-semibold']">
                   {{ option.label }}
                 </div>
                 <div
                   v-if="option.secondaryLabel"
                   :class="[
-                    'tw-text-xs tw-truncate',
+                    'tw-text-xs',
                     active ? 'tw-text-white/75' : 'tw-text-neutral-400',
                     selected && 'tw-font-semibold',
                   ]"

--- a/resources/js/components/MemberList.vue
+++ b/resources/js/components/MemberList.vue
@@ -119,6 +119,7 @@
               v-model="member.role"
               :options="roles"
               :canAddNewOption="true"
+              class="tw-min-w-[10rem]"
               @addNewOption="
                 (newRole) => $emit('update:roles', [...roles, newRole])
               "

--- a/resources/js/components/MemberList.vue
+++ b/resources/js/components/MemberList.vue
@@ -254,3 +254,10 @@ export default {
   width: 300px;
 }
 </style>
+<style scoped>
+.table,
+.form-control,
+button {
+  font-size: 0.875rem;
+}
+</style>

--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -92,22 +92,24 @@
       </div>
     </div>
 
-    <MemberList
-      v-if="!showGantt"
-      :show_unit="show_unit"
-      :roles="roles"
-      :editing="editing"
-      :filteredList="filteredList"
-      :filterList="filterList"
-      :includePreviousMembers="includePreviousMembers"
-      :viewType="viewType"
-      :currentSort="currentSort"
-      :currentSortDir="currentSortDir"
-      @remove="removeMember"
-      @update:roles="(val) => $emit('update:roles', val)"
-      @sort="sort"
-    >
-    </MemberList>
+    <div class="tw-max-w-full tw-overflow-auto">
+      <MemberList
+        v-if="!showGantt"
+        :show_unit="show_unit"
+        :roles="roles"
+        :editing="editing"
+        :filteredList="filteredList"
+        :filterList="filterList"
+        :includePreviousMembers="includePreviousMembers"
+        :viewType="viewType"
+        :currentSort="currentSort"
+        :currentSortDir="currentSortDir"
+        @remove="removeMember"
+        @update:roles="(val) => $emit('update:roles', val)"
+        @sort="sort"
+      >
+      </MemberList>
+    </div>
     <Gantt
       v-if="showGantt"
       :members="filteredList"

--- a/resources/js/pages/GroupPage.vue
+++ b/resources/js/pages/GroupPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <DefaultLayout>
+  <WideLayout>
     <div>
       <div v-if="error" class="alert alert-danger" role="alert">
         {{ error }}
@@ -16,13 +16,13 @@
         @update:reload="groupStore.fetchGroup(props.groupId)"
       />
     </div>
-  </DefaultLayout>
+  </WideLayout>
 </template>
 
 <script lang="ts" setup>
 import ViewGroup from "@/components/ViewGroup.vue";
 import EditGroup from "@/components/EditGroup.vue";
-import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import WideLayout from "@/layouts/WideLayout.vue";
 import { usePageTitle } from "@/utils/usePageTitle";
 import { Group } from "@/types";
 import { computed, ref, watch } from "vue";


### PR DESCRIPTION

![ScreenShot 2024-04-29 at 15 09 04@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/a5b741b6-e6b7-408a-9a8a-6525be69e80b)
![ScreenShot 2024-04-29 at 15 09 18@2x](https://github.com/UMN-LATIS/bluesheet/assets/980170/3c997d21-8e73-4255-8078-5254068e4d36)

- permit text to wrap, rather than truncate in combobox options
- Changed group page to use `<WideLayout>` some of those fields would be pretty long.
- add min-width to the role combobox in member list
- fix MemberList table overflowing the post-it container: now it scrolls.

On dev for testing

Resolves #160 

