### PR TITLE
clear add member modal after adding a member successfully

### DIFF
--- a/resources/js/components/EditGroup.vue
+++ b/resources/js/components/EditGroup.vue
@@ -444,6 +444,9 @@ export default {
     handleUserSelected(user) {
       this.newUserId = user.mail;
 
+      // reset user lookup input
+      this.userLookupText = "";
+
       this.$nextTick(() => {
         this.$refs.addMemberRef.focus();
       });


### PR DESCRIPTION
In the Add Member Modal,  this clears the name input field once a user is selected. Fixes #158

