### PR TITLE
Update Parent Group dropdown on edit group page to prevent users selecting groups they don't manage

### DIFF
--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -25,7 +25,10 @@ class GroupController extends Controller
         // batch get group permissions rather than using Group Policy
         // directly to avoid n+1 queries. Maybe this should be elsewhere,
         // so that it doesn't diverge from GroupPolicy update method?
-        $managedGroupIds = $request->user()->getManagedGroups()->pluck('id')->keyBy(fn ($id) => $id); // key by id for faster lookup
+        $managedGroupIds = $request->user()
+            ->getManagedGroups()
+            ->pluck('id')
+            ->keyBy(fn ($id) => $id);
         $canModifyAnyGroup = $request->user()->can(Permissions::EDIT_GROUPS);
 
         // Enhance groups with permission data

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -8,6 +8,7 @@ use App\Http\Resources\Membership as MembershipResource;
 use App\ParentOrganization;
 use DB;
 use App\Group;
+use App\Constants\Permissions;
 
 class GroupController extends Controller
 {

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -16,10 +16,25 @@ class GroupController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index()
-    {
+    public function index(Request $request) {
+        $groups = Group::where("active_group", 1)
+            ->with("groupType", "parentGroup", "childGroups", "parentOrganization", "artifacts", "activeMembers")
+            ->get();
 
-         return \App\Group::where("active_group",1)->get()->load("groupType", "parentGroup", "childGroups", "parentOrganization", "artifacts", "activeMembers");
+        // batch get group permissions rather than using Group Policy
+        // directly to avoid n+1 queries. Maybe this should be elsewhere,
+        // so that it doesn't diverge from GroupPolicy update method?
+        $managedGroupIds = $request->user()->getManagedGroups()->pluck('id')->keyBy(fn ($id) => $id); // key by id for faster lookup
+        $canModifyAnyGroup = $request->user()->can(Permissions::EDIT_GROUPS);
+
+        // Enhance groups with permission data
+        return $groups->map(function ($group) use ($managedGroupIds, $canModifyAnyGroup) {
+            $group->canCurrentUser = [
+                'update' => $canModifyAnyGroup || $managedGroupIds->has($group->id),
+                'delete' => $canModifyAnyGroup || $managedGroupIds->has($group->id),
+            ];
+            return $group;
+        });
     }
 
     public function getGroupsByFolder(ParentOrganization $parentOrganization=null) {

--- a/resources/js/components/EditGroup.vue
+++ b/resources/js/components/EditGroup.vue
@@ -369,7 +369,7 @@ export default {
             throw new Error(`Group ${group.id} has no canCurrentUser property`);
           }
           // if this is the current saved parent group
-          // permit it to be selected
+          // permit it to remain selected
           if (group.id == this.group?.parent_group_id) {
             return true;
           }

--- a/resources/js/utils/doesGroupHaveSubgroup.ts
+++ b/resources/js/utils/doesGroupHaveSubgroup.ts
@@ -1,0 +1,15 @@
+import { ChildGroup, Group } from "@/types";
+
+export function doesGroupHaveSubgroup(
+  group: Group | ChildGroup,
+  subgroup: Group | ChildGroup,
+) {
+  return (
+    group.child_groups?.some((subgroupItem) => {
+      return (
+        subgroupItem.id === subgroup.id ||
+        doesGroupHaveSubgroup(subgroupItem, subgroup)
+      );
+    }) ?? false
+  );
+}

--- a/resources/js/utils/index.ts
+++ b/resources/js/utils/index.ts
@@ -6,3 +6,4 @@ export { getTempId, isTempId } from "./tempIdHelpers";
 export { parseIntFromRouteParam } from "./parseIntFromRouteParam";
 export { sortByValueAtPath } from "./sortByValueAtPath";
 export { isValidUrl } from "./isValidUrl";
+export { doesGroupHaveSubgroup } from "./doesGroupHaveSubgroup";


### PR DESCRIPTION
Resolves #159 

Currently, Bluesheet Managers can set the parent group of their managed group to any group. This can be problematic if the change it to a group they don't have permissions to edit, or if they choose a group's own subgroup, creating a circular reference.

This updates the ParentGroup dropdown on the EditGroup page to only show:
- groups that the current user can update
- groups that are not subgroups

To support this, the `/api/group` endpoint is updated to append `canCurrentUser` permissions info to each group.  To avoid n+1 queries, the `GroupController#index` batch gets permission info rather than deferring to the GroupPolicy directly.

On dev for testing.

<img src="https://github.com/UMN-LATIS/bluesheet/assets/980170/0eff9ffe-6f29-49d4-86bd-85f256446121" alt="shorter list of parent group options" width="400" />
