### PR TITLE
denote group managers in roles and members list with a badge

### DIFF
--- a/resources/js/components/ManagerBadge.vue
+++ b/resources/js/components/ManagerBadge.vue
@@ -1,0 +1,30 @@
+<template>
+  <div
+    class="tw-inline-flex tw-text-yellow-600 tw-gap-1 tw-items-center tw-leading-none tw-text-xs"
+    title="Group Manager"
+    :class="{
+      'tw-bg-yellow-50 tw-px-2 tw-py-1 tw-rounded-full tw-border tw-border-solid tw-border-yellow-200 tw-leading-none':
+        showLabel,
+    }"
+  >
+    <i class="fas fa-shield-alt tw-m-0"></i>
+    <span
+      class="tw-uppercase"
+      :class="{
+        'tw-sr-only': !showLabel,
+      }"
+      >Manager</span
+    >
+  </div>
+</template>
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    showLabel?: boolean;
+  }>(),
+  {
+    showLabel: true,
+  },
+);
+</script>
+<style scoped></style>

--- a/resources/js/components/MemberList.vue
+++ b/resources/js/components/MemberList.vue
@@ -79,7 +79,7 @@
           />
         </th>
         <th
-          v-if="viewType === 'group' && (editing || $can('edit groups'))"
+          v-if="viewType === 'group' && editing"
           scope="col"
           class="tw-text-center"
         >
@@ -106,6 +106,11 @@
           <span v-if="!member.user.id || !$can('view users')"
             >{{ member.user.surname }}, {{ member.user.givenname }}</span
           >
+          <ManagerBadge
+            v-if="member.admin && showManagerBadge"
+            :showLabel="!editing"
+            class="tw-ml-2"
+          />
         </td>
         <td v-if="show_unit && viewType == 'group'">{{ member.user.ou }}</td>
 
@@ -190,15 +195,9 @@
           ></i>
           <i v-else class="searchIcon fa fa-close"></i>
         </td>
-        <td
-          v-if="viewType === 'group' && ($can('edit groups') || editing)"
-          class="tw-text-center"
-        >
-          <div v-if="editing">
-            <input v-model="member.admin" type="checkbox" />
-            <label class="sr-only">BlueSheet Manager</label>
-          </div>
-          <CheckIcon v-else-if="member.admin" />
+        <td v-if="viewType === 'group' && editing" class="tw-text-center">
+          <input v-model="member.admin" type="checkbox" />
+          <label class="sr-only">BlueSheet Manager</label>
         </td>
         <td v-if="editing" class="tw-text-center">
           <button
@@ -218,15 +217,15 @@
 import GroupTitle from "./GroupTitle.vue";
 import { dayjs, $can } from "@/utils";
 import ComboBox from "./ComboBox.vue";
-import { CheckIcon } from "@/icons";
 import SortableLink from "./SortableLink.vue";
+import ManagerBadge from "./ManagerBadge.vue";
 
 export default {
   components: {
     GroupTitle,
     ComboBox,
-    CheckIcon,
     SortableLink,
+    ManagerBadge,
   },
   props: [
     "editing",
@@ -238,6 +237,7 @@ export default {
     "viewType", // "group" or "role"
     "currentSort",
     "currentSortDir",
+    "showManagerBadge",
   ],
   emits: ["remove", "update:roles", "sort"],
   methods: {

--- a/resources/js/components/Members.vue
+++ b/resources/js/components/Members.vue
@@ -100,6 +100,7 @@
         :show_unit="show_unit"
         :roles="roles"
         :editing="editing"
+        :showManagerBadge="$can('edit groups') || group?.canCurrentUser?.update"
         :filteredList="filteredList"
         :filterList="filterList"
         :includePreviousMembers="includePreviousMembers"

--- a/resources/js/components/Roles.vue
+++ b/resources/js/components/Roles.vue
@@ -42,6 +42,14 @@
             <span v-if="!membership.group.id"
               ><GroupTitle :group="membership.group"
             /></span>
+            <div
+              v-if="membership.admin"
+              class="tw-inline-flex tw-bg-yellow-50 tw-text-yellow-600 tw-gap-1 tw-items-baseline tw-px-1 tw-rounded-full tw-text-xs tw-border tw-border-solid tw-border-yellow-200 tw-leading-none"
+              title="Group Manager"
+            >
+              <i class="fas fa-shield-alt"></i>
+              <span class="tw-uppercase">Manager</span>
+            </div>
           </Td>
           <Td>{{ membership.role.label }}</Td>
           <Td>

--- a/resources/js/components/Roles.vue
+++ b/resources/js/components/Roles.vue
@@ -37,19 +37,16 @@
             <router-link
               v-if="membership.group.id"
               :to="{ name: 'group', params: { groupId: membership.group.id } }"
-              ><GroupTitle :group="membership.group"
-            /></router-link>
+            >
+              <GroupTitle :group="membership.group" />
+            </router-link>
             <span v-if="!membership.group.id"
               ><GroupTitle :group="membership.group"
             /></span>
-            <div
-              v-if="membership.admin"
-              class="tw-inline-flex tw-bg-yellow-50 tw-text-yellow-600 tw-gap-1 tw-items-baseline tw-px-1 tw-rounded-full tw-text-xs tw-border tw-border-solid tw-border-yellow-200 tw-leading-none"
-              title="Group Manager"
-            >
-              <i class="fas fa-shield-alt"></i>
-              <span class="tw-uppercase">Manager</span>
-            </div>
+            <ManagerBadge
+              v-if="membership.admin && (isCurrentUser || $can('edit groups'))"
+              class="tw-ml-2"
+            />
           </Td>
           <Td>{{ membership.role.label }}</Td>
           <Td>
@@ -75,14 +72,21 @@
 <script lang="ts" setup>
 import { ref, computed } from "vue";
 import GroupTitle from "../components/GroupTitle.vue";
-import { dayjs } from "@/utils";
+import { dayjs, $can } from "@/utils";
 import { Table, Td, Th, THead, TBody } from "@/components/Table";
 import { Membership } from "@/types";
 import CheckboxGroup from "./CheckboxGroup.vue";
+import ManagerBadge from "./ManagerBadge.vue";
 
-const props = defineProps<{
-  memberships: Membership[];
-}>();
+const props = withDefaults(
+  defineProps<{
+    memberships: Membership[];
+    isCurrentUser?: boolean;
+  }>(),
+  {
+    isCurrentUser: false,
+  },
+);
 
 const showPastRoles = ref(false);
 
@@ -105,9 +109,5 @@ function isCurrentOrFutureRole(role: Membership) {
 const filteredList = computed((): Membership[] => {
   if (showPastRoles.value) return sortedList.value;
   return sortedList.value.filter(isCurrentOrFutureRole);
-});
-
-const hasPastRoles = computed((): boolean => {
-  return sortedList.value.some((role) => !isCurrentOrFutureRole(role));
 });
 </script>

--- a/resources/js/pages/UserHomePage.vue
+++ b/resources/js/pages/UserHomePage.vue
@@ -22,19 +22,24 @@
             v-model="user.notify_of_favorite_changes"
             label="Changes"
             description="Notify me when my favorite groups and roles change."
-            @update:modelValue="api.updateUser(user)"
+            @update:modelValue="api.updateUser(user!)"
           />
           <CheckboxGroup
             id="send_email_reminders"
             v-model="user.send_email_reminders"
             label="Reminders"
             description="Send me occasional reminders to update my groups."
-            @update:modelValue="api.updateUser(user)"
+            @update:modelValue="api.updateUser(user!)"
           />
         </aside>
       </div>
 
-      <Roles id="v-step-4" :memberships="memberships" class="tw-mt-12"></Roles>
+      <Roles
+        id="v-step-4"
+        :memberships="memberships"
+        :isCurrentUser="isCurrentUser"
+        class="tw-mt-12"
+      />
 
       <LeavesTable
         v-if="canViewLeaves"


### PR DESCRIPTION
Currently, there's no straight forward way for a user to see which groups they can manage.

- adds a "Manager" badge next to User page, Group page, and Roles page.
- removes the redundant BlueSheet Manager column on the Group page when in view mode. Edit mode retains the BlueSheet Manager  checkbox column, of course.

User Page:
<img src="https://github.com/UMN-LATIS/bluesheet/assets/980170/6925ca80-87b7-4a64-a19f-cfb24bc1b9d2" width="600">

Group page, View mode:
<img src="https://github.com/UMN-LATIS/bluesheet/assets/980170/474e8e3c-f5d5-49aa-ab30-fb1831fa9e15" width="600" />

Group page, Edit mode:
<img src="https://github.com/UMN-LATIS/bluesheet/assets/980170/c8ce14f8-029b-40c0-9d5e-80edfef7b1c2" width="600" />

Roles page
<img src="https://github.com/UMN-LATIS/bluesheet/assets/980170/86ad6015-16fd-46e5-b03d-16ec6a871cef" width="600" />

On dev for testing