### PR TITLE
fix: leaves report whitescreens when given/surname is null

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - run: cp .env.example .env
 
@@ -46,14 +46,14 @@ jobs:
         run: yarn test:unit
 
       - name: Run E2E tests with Cypress
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           wait-on: "http://localhost"
           browser: chrome
           config: baseUrl=http://localhost
 
       - name: Upload test screenshots if any
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,25 +22,25 @@ jobs:
       - run: composer install --no-interaction --prefer-dist
 
       - name: Build
-        run: docker-compose build
+        run: docker compose build
 
       - name: Start
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Check
         run: |
-          docker-compose ps --all
+          docker compose ps --all
 
       - run: yarn install --frozen-lockfile
       - run: yarn build
-      - run: docker-compose exec -T app ./bin/ci.sh
-      - run: docker-compose exec -T app php artisan key:generate
-      - run: docker-compose exec -T app php artisan migrate:fresh
-      - run: docker-compose exec -T app php artisan db:seed
-      - run: docker-compose exec -T app chmod -R 777 storage
+      - run: docker compose exec -T app ./bin/ci.sh
+      - run: docker compose exec -T app php artisan key:generate
+      - run: docker compose exec -T app php artisan migrate:fresh
+      - run: docker compose exec -T app php artisan db:seed
+      - run: docker compose exec -T app chmod -R 777 storage
 
       - name: Run integration tests with Pest
-        run: docker-compose exec -T app ./vendor/bin/pest
+        run: docker compose exec -T app ./vendor/bin/pest
 
       - name: Run unit tests with Jest
         run: yarn test:unit

--- a/app/Http/Resources/PersonResource.php
+++ b/app/Http/Resources/PersonResource.php
@@ -15,8 +15,8 @@ class PersonResource extends JsonResource {
     public function toArray($request) {
         return [
             'id' => $this->id,
-            'givenName' => $this->givenname,
-            'surName' => $this->surname,
+            'givenName' => $this->givenname ?? '',
+            'surName' => $this->surname ?? '',
             'displayName' => $this->displayName,
             'email' => $this->email,
             'title' => $this->title,


### PR DESCRIPTION
Return an empty string instead of null for missing given/surnames – I ran into null values for some users (running locally with an old db), which caused the LeavesReport to throw and whitescreen when sorting.