### PR TITLE
fix: null returned from getTerms()

### DIFF
--- a/app/Library/Bandaid.php
+++ b/app/Library/Bandaid.php
@@ -26,7 +26,7 @@ class Bandaid {
         Http::globalOptions([
             'allow_redirects' => false,
         ]);
-        
+
         $this->baseUri = config('bandaid.baseUri');
     }
 
@@ -142,7 +142,7 @@ class Bandaid {
      */
     public function getTerms(): array {
         try {
-            $result = $this->cachedGet('/classes/terms/');
+            $result = $this->cachedGet('/classes/terms');
             return $result;
         } catch (RequestException $e) {
             $msg = $e->getMessage();


### PR DESCRIPTION
In previous PR, we changed the allow_redirects option to false in the Bandaid service to fix a failing CI test:

```
Http::globalOptions([
  'allow_redirects' => false,
]);
```

The side effect was that `Bandaid::getTerms()` would fail because it relied on a redirect. It's url `/classes/terms/` contained a trailing slashes, which previously would be redirected to `/classes/terms` (no trailing slash).

This removes the trailing slash to resolve the issue.
