### PR TITLE
select leave start and end dates from payroll dates

### DIFF
--- a/app/Http/Controllers/LeaveController.php
+++ b/app/Http/Controllers/LeaveController.php
@@ -146,7 +146,6 @@ class LeaveController extends Controller {
         // start from 1 year before current FY and go 1 year after
         // adding an entry for every 14 days
         $thisStartDate = $currentFYStart->copy();
-        $previousTerm = null;
         while ($thisStartDate->lte($currentFYStart->copy()->addYears(3))) {
             $thisEndDate = $thisStartDate->copy()->addDays(13);
             $thisTerm = $this->bandaid
@@ -157,23 +156,14 @@ class LeaveController extends Controller {
             $startDateOptions[] = [
                 'date' => $thisStartDate->format('Y-m-d'),
                 'term' => $thisTerm,
-                'isFirstTermOption' => $thisTerm && $thisTerm !== $previousTerm,
             ];
-
-            // if this term is new term and the previous term was defined,
-            // then mark the previous end date as last option in term
-            if ($previousTerm && $thisTerm !== $previousTerm) {
-                $endDateOptions[count($endDateOptions) - 1]['isLastTermOption'] = true;
-            }
 
             $endDateOptions[] = [
                 'date' => $thisEndDate->format('Y-m-d'),
                 'term' => $thisTerm,
-                'isLastTermOption' => false,
             ];
 
             $thisStartDate->addDays(14);
-            $previousTerm = $thisTerm;
         }
 
         return response()->json([

--- a/app/Library/Bandaid.php
+++ b/app/Library/Bandaid.php
@@ -242,15 +242,10 @@ class Bandaid {
     public function getTermsOverlappingDates($startDate, $endDate) {
         $terms = $this->getCLATerms();
         return $terms->filter(function ($term) use ($startDate, $endDate) {
-            $termStartDate = $term->TERM_BEGIN_DT;
-            $termEndDate = $term->TERM_END_DT;
-
-            // is term start or end between the leave start and end dates?
-            $isTermStartInRange = ($startDate <= $termStartDate && $termStartDate <= $endDate);
-
-            $isTermEndInRange = ($startDate <= $termEndDate && $termEndDate <= $endDate);
-
-            return ($isTermStartInRange || $isTermEndInRange);
+            $termStartDate = new Carbon($term->TERM_BEGIN_DT);
+            $termEndDate = new Carbon($term->TERM_END_DT);
+            return $startDate->between($termStartDate, $termEndDate)
+                || $endDate->between($termStartDate, $termEndDate);
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:e2e": "npm run cypress:headless"
   },
   "dependencies": {
+    "@floating-ui/vue": "^1.1.4",
     "@headlessui/vue": "^1.7.16",
     "@umn-latis/cla-vue-template": "^1.1.0",
     "@vitejs/plugin-vue": "^4.2.3",

--- a/resources/js/api/api.ts
+++ b/resources/js/api/api.ts
@@ -193,3 +193,8 @@ export async function getPermissionsForSubgroupsOf(groupId: T.Group["id"]) {
 
   return res.data;
 }
+
+export async function getLeaveDateOptions() {
+  const res = await axios.get<T.ApiLeaveDateOptions>(`/api/leaves/dateOptions`);
+  return res.data;
+}

--- a/resources/js/components/ComboBox.vue
+++ b/resources/js/components/ComboBox.vue
@@ -30,6 +30,7 @@
       -->
       <ComboboxButton as="div">
         <ComboboxInput
+          ref="anchorRef"
           class="combobox__input tw-w-full tw-rounded tw-border-0 tw-bg-white tw-py-2 tw-pl-3 tw-pr-10 tw-text-neutral-900 tw-ring-1 tw-ring-inset tw-ring-neutral-300 focus:tw-ring-2 focus:tw-ring-inset focus:tw-ring-blue-600 sm:tw-leading-6"
           :class="inputClass"
           :displayValue="(item) => (item as ComboBoxOption | null)?.label ?? ''"
@@ -47,9 +48,11 @@
           />
         </div>
       </ComboboxButton>
-      <Transition name="fade-slide">
+      <Teleport to="body">
         <ComboboxOptions
-          class="tw-absolute tw-z-10 tw-mt-1 tw-max-h-60 tw-w-full tw-overflow-auto tw-rounded-md tw-bg-white tw-py-1 tw-text-base tw-shadow-lg tw-ring-1 tw-ring-black tw-ring-opacity-5 focus:tw-outline-none sm:tw-text-sm tw-pl-0"
+          ref="floatingRef"
+          class="tw-absolute tw-z-10 tw-mt-1 tw-max-h-60 tw-w-56 tw-overflow-auto tw-rounded-md tw-bg-white tw-py-1 tw-text-base tw-shadow-lg tw-ring-1 tw-ring-black tw-ring-opacity-5 focus:tw-outline-none sm:tw-text-sm tw-pl-0"
+          :style="floatingStyles"
         >
           <ComboboxOption
             v-for="option in filteredOptions"
@@ -110,7 +113,7 @@
             </button>
           </div>
         </ComboboxOptions>
-      </Transition>
+      </Teleport>
     </div>
   </Combobox>
 </template>
@@ -128,6 +131,7 @@ import {
 } from "@headlessui/vue";
 import { CSSClass } from "@/types";
 import Label from "./Label.vue";
+import { useFloating, offset, autoPlacement } from "@floating-ui/vue";
 
 export interface ComboBoxOption {
   id?: string | number; // new options might have an undefined id
@@ -204,4 +208,11 @@ function handleAddNewOption(newOptionLabel: string) {
   emit("addNewOption", newOption);
   emit("update:modelValue", newOption);
 }
+
+const anchorRef = ref<HTMLElement | null>(null);
+const floatingRef = ref<HTMLElement | null>(null);
+
+const { floatingStyles } = useFloating(anchorRef, floatingRef, {
+  middleware: [offset(10), autoPlacement()],
+});
 </script>

--- a/resources/js/components/ComboBox.vue
+++ b/resources/js/components/ComboBox.vue
@@ -51,7 +51,7 @@
       <Teleport to="body">
         <ComboboxOptions
           ref="floatingRef"
-          class="tw-absolute tw-z-10 tw-mt-1 tw-max-h-60 tw-w-56 tw-overflow-auto tw-rounded-md tw-bg-white tw-py-1 tw-text-base tw-shadow-lg tw-ring-1 tw-ring-black tw-ring-opacity-5 focus:tw-outline-none sm:tw-text-sm tw-pl-0"
+          class="tw-absolute tw-z-10 tw-mt-1 tw-max-h-72 tw-w-56 tw-overflow-auto tw-rounded-md tw-bg-white tw-py-1 tw-text-base tw-shadow-lg tw-ring-1 tw-ring-black tw-ring-opacity-5 focus:tw-outline-none sm:tw-text-sm tw-pl-0"
           :style="floatingStyles"
         >
           <ComboboxOption

--- a/resources/js/components/ComboBox.vue
+++ b/resources/js/components/ComboBox.vue
@@ -31,7 +31,7 @@
       <ComboboxButton as="div">
         <ComboboxInput
           ref="anchorRef"
-          class="combobox__input tw-w-full tw-rounded tw-border-0 tw-bg-white tw-py-2 tw-pl-3 tw-pr-10 tw-text-neutral-900 tw-ring-1 tw-ring-inset tw-ring-neutral-300 focus:tw-ring-2 focus:tw-ring-inset focus:tw-ring-blue-600 sm:tw-leading-6"
+          class="combobox__input tw-w-full tw-rounded tw-bg-transparent tw-border-0 tw-py-2 tw-pl-3 tw-pr-10 tw-text-neutral-900 tw-ring-1 tw-ring-inset tw-ring-neutral-300 focus:tw-ring-2 focus:tw-ring-inset focus:tw-ring-blue-600 sm:tw-leading-6"
           :class="inputClass"
           :displayValue="(item) => (item as ComboBoxOption | null)?.label ?? ''"
           :placeholder="placeholder"

--- a/resources/js/components/InputGroup.vue
+++ b/resources/js/components/InputGroup.vue
@@ -20,7 +20,7 @@
       class="form-control tw-text-sm tw-bg-transparent tw-border placeholder:tw-text-neutral-400 placeholder:tw-italic"
       :class="[
         {
-          'is-invalid': !isValidComputed,
+          'tw-border tw-border-red-500 tw-border-solid': !isValidComputed,
         },
         inputClass,
       ]"

--- a/resources/js/components/LeavesTable/LeaveTableRow.vue
+++ b/resources/js/components/LeavesTable/LeaveTableRow.vue
@@ -92,7 +92,13 @@
         '!tw-px-2 !tw-py-1': isEditing,
       }"
     >
-      <InputGroup
+      <SelectLeaveDate
+        v-if="isEditing"
+        variant="end"
+        :modelValue="localLeave.end_date"
+        @update:modelValue="(date) => (localLeave.end_date = date ?? '')"
+      />
+      <!-- <InputGroup
         v-if="isEditing"
         v-model="localLeave.end_date"
         label="start date"
@@ -103,7 +109,7 @@
           (endDate) => areStartAndEndDatesValid(localLeave.start_date, endDate)
         "
         :validateWhenUntouched="true"
-      />
+      /> -->
       <span v-else>{{ dayjs(leave.end_date).format("MMM D, YYYY") }}</span>
     </Td>
     <Td v-if="canEditLeave">

--- a/resources/js/components/LeavesTable/LeaveTableRow.vue
+++ b/resources/js/components/LeavesTable/LeaveTableRow.vue
@@ -2,8 +2,8 @@
   <tr
     data-cy="leaveRow"
     :class="{
-      'is-new-leave': isNewLeave,
-      'is-invalid-leave tw-bg-red-50': !isLeaveValid,
+      'tw-bg-blue-50': isNewLeave,
+      'tw-bg-yellow-50': !isLeaveValid,
       'is-past-leave tw-bg-neutral-100':
         !isNewLeave && !isCurrentOrFutureLeave && !isEditing,
       'is-past-leave--editing tw-bg-neutral-100':
@@ -37,6 +37,7 @@
         label="description"
         :showLabel="false"
         :validator="isNotEmptyString"
+        :validateWhenUntouched="true"
       />
       <span v-else>{{ leave.description }}</span>
     </Td>
@@ -82,6 +83,10 @@
         v-if="isEditing"
         variant="start"
         :modelValue="localLeave.start_date"
+        :validator="
+          (startDate) =>
+            areStartAndEndDatesValid(startDate, localLeave.end_date)
+        "
         @update:modelValue="(date) => (localLeave.start_date = date ?? '')"
       />
       <span v-else>{{ dayjs(leave.start_date).format("MMM D, YYYY") }}</span>
@@ -96,6 +101,9 @@
         v-if="isEditing"
         variant="end"
         :modelValue="localLeave.end_date"
+        :validator="
+          (endDate) => areStartAndEndDatesValid(localLeave.start_date, endDate)
+        "
         @update:modelValue="(date) => (localLeave.end_date = date ?? '')"
       />
       <!-- <InputGroup
@@ -246,9 +254,13 @@ const areStartAndEndDatesValid = (startDate: unknown, endDate: unknown) =>
   dayjs(endDate).isValid() &&
   dayjs(endDate).isAfter(dayjs(startDate));
 
-const isLeaveValid = (leave: Leave) =>
-  [leave.description, leave.type, leave.status].every(isNotEmptyString) &&
-  areStartAndEndDatesValid(leave.start_date, leave.end_date);
+const isLeaveValid = computed(() => {
+  return (
+    [localLeave.description, localLeave.type, localLeave.status].every(
+      isNotEmptyString,
+    ) && areStartAndEndDatesValid(localLeave.start_date, localLeave.end_date)
+  );
+});
 
 const isCurrentOrFutureLeave = computed(() =>
   dayjs(props.leave.end_date).isAfter(dayjs()),

--- a/resources/js/components/LeavesTable/LeaveTableRow.vue
+++ b/resources/js/components/LeavesTable/LeaveTableRow.vue
@@ -78,18 +78,11 @@
         '!tw-px-2 !tw-py-1': isEditing,
       }"
     >
-      <InputGroup
+      <SelectLeaveDate
         v-if="isEditing"
-        v-model="localLeave.start_date"
-        :required="true"
-        label="start date"
-        :showLabel="false"
-        type="date"
-        :validator="
-          (startDate) =>
-            areStartAndEndDatesValid(startDate, localLeave.end_date)
-        "
-        :validateWhenUntouched="true"
+        variant="start"
+        :modelValue="localLeave.start_date"
+        @update:modelValue="(date) => (localLeave.start_date = date ?? '')"
       />
       <span v-else>{{ dayjs(leave.start_date).format("MMM D, YYYY") }}</span>
     </Td>
@@ -164,6 +157,7 @@ import { ChevronDownIcon, ChevronRightIcon } from "@/icons";
 import LeaveArtifacts from "./LeaveArtifacts.vue";
 import SmallButton from "./SmallButton.vue";
 import { useUserStore } from "@/stores/useUserStore";
+import SelectLeaveDate from "./SelectLeaveDate.vue";
 
 const props = defineProps<{
   leave: Leave;

--- a/resources/js/components/LeavesTable/SelectLeaveDate.vue
+++ b/resources/js/components/LeavesTable/SelectLeaveDate.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="">
+    <!-- <select v-if="variant === 'start'" :value="modelValue">
+      <option value="">-- Select a date --</option>
+      <option v-for="opt in startDateOptions" :key="opt.date" :value="opt.date">
+        {{ opt.date }} - {{ opt.term }}
+      </option>
+    </select> -->
+    <ComboBox
+      :modelValue="localComboBoxValue"
+      :label="variant === 'start' ? 'Leave Start Date' : 'Leave End Date'"
+      :showLabel="false"
+      :options="comboboxOptions"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+import { useLeaveDateOptions } from "@/composables/useLeaveDateOptions";
+import { computed, ref } from "vue";
+import ComboBox, { ComboBoxOption } from "@/components/ComboBox.vue";
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: string;
+    variant?: "start" | "end";
+  }>(),
+  {
+    modelValue: "",
+    variant: "start",
+  },
+);
+
+defineEmits<{
+  (event: "update:modelValue", value: string): void;
+}>();
+
+const { startDateOptions } = useLeaveDateOptions();
+
+interface TermLabelLookup {
+  [date: string]: {
+    date: string;
+    term: string;
+    weekNumber: number;
+  };
+}
+
+const dateToTermLookup = computed(() => {
+  return startDateOptions.value.reduce(
+    (acc, option, index): TermLabelLookup => {
+      const previousTerm = index === 0 ? acc[index - 1] : null;
+
+      if (!previousTerm) {
+        acc[option.date] = {
+          date: option.date,
+          term: option.term,
+          weekNumber: 1,
+        };
+        return acc;
+      }
+
+      const isNewTerm = option.term === previousTerm.term;
+
+      acc[option.date] = {
+        date: option.date,
+        term: option.term,
+        weekNumber: isNewTerm ? 1 : previousTerm.weekNumber + 1,
+      };
+      return acc;
+    },
+    {},
+  );
+});
+
+const localComboBoxValue = computed((): ComboBoxOption | null => {
+  if (!props.modelValue) {
+    return null;
+  }
+  const dateTermInfo = dateToTermLookup.value[props.modelValue];
+  if (!dateTermInfo) {
+    return null;
+  }
+
+  return {
+    id: props.modelValue,
+    label: dateTermInfo.date,
+    secondaryLabel: `${dateTermInfo.term} - Week ${dateTermInfo.weekNumber}`,
+  };
+});
+
+const comboboxOptions = computed(() => {
+  return startDateOptions.value.map((opt) => ({
+    id: opt.date,
+    label: opt.date,
+    secondaryLabel: `${opt.term} - Week ${
+      dateToTermLookup.value[opt.date].weekNumber
+    }`,
+  }));
+});
+</script>
+<style scoped></style>

--- a/resources/js/components/LeavesTable/SelectLeaveDate.vue
+++ b/resources/js/components/LeavesTable/SelectLeaveDate.vue
@@ -6,7 +6,10 @@
       :label="variant === 'start' ? 'Leave Start Date' : 'Leave End Date'"
       :showLabel="false"
       :options="comboboxOptions"
-      class="tw-w-36"
+      class="tw-w-40"
+      :inputClass="{
+        '!tw-border-red-500 tw-border tw-solid': !isDateValid,
+      }"
       @update:modelValue="
         (comboboxOption) =>
           $emit('update:modelValue', comboboxOption?.id as string)
@@ -18,7 +21,9 @@
       type="date"
       :modelValue="modelValue"
       :showLabel="false"
-      class="tw-w-36"
+      class="tw-w-40"
+      :validator="validator"
+      :validateWhenUntouched="true"
       @update:modelValue="$emit('update:modelValue', $event)"
     />
     <button
@@ -31,22 +36,24 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 import ComboBox, { ComboBoxOption } from "@/components/ComboBox.vue";
 import InputGroup from "../InputGroup.vue";
 import { VDotsIcon } from "@/icons";
 import { useUserStore } from "@/stores/useUserStore";
-import { DateWithTermAndWeekNum, ISODate } from "@/types";
+import { DateWithTermAndWeekNum } from "@/types";
 import dayjs from "dayjs";
 
 const props = withDefaults(
   defineProps<{
     modelValue: string;
     variant?: "start" | "end";
+    validator?: (value: unknown) => boolean;
   }>(),
   {
     modelValue: "",
     variant: "start",
+    validator: () => true,
   },
 );
 
@@ -88,5 +95,9 @@ const localComboBoxValue = computed((): ComboBoxOption | null => {
 const comboboxOptions = computed(() =>
   Object.values(currentLookupVariant.value).map(toComboBoxOption),
 );
+
+const isDateValid = computed(() => {
+  return props.validator(props.modelValue);
+});
 </script>
 <style scoped></style>

--- a/resources/js/composables/useLeaveDateOptions.ts
+++ b/resources/js/composables/useLeaveDateOptions.ts
@@ -1,11 +1,8 @@
 import * as api from "@/api";
 import * as T from "@/types";
-import { reactive, toRefs, type Ref } from "vue";
+import { computed, reactive, toRefs } from "vue";
 
-export const useLeaveDateOptions = (): {
-  startDateOptions: Ref<T.LeaveStartDateOption[]>;
-  endDateOptions: Ref<T.LeaveEndDateOption[]>;
-} => {
+export const useLeaveDateOptions = () => {
   const state = reactive({
     loadStatus: "idle" as "idle" | "loading" | "success" | "error",
     startDateOptions: [] as T.LeaveStartDateOption[],
@@ -27,5 +24,8 @@ export const useLeaveDateOptions = (): {
       });
   }
 
-  return toRefs(state);
+  return {
+    ...toRefs(state),
+    isLoaded: computed(() => state.loadStatus === "success"),
+  };
 };

--- a/resources/js/composables/useLeaveDateOptions.ts
+++ b/resources/js/composables/useLeaveDateOptions.ts
@@ -1,0 +1,31 @@
+import * as api from "@/api";
+import * as T from "@/types";
+import { reactive, toRefs, type Ref } from "vue";
+
+export const useLeaveDateOptions = (): {
+  startDateOptions: Ref<T.LeaveStartDateOption[]>;
+  endDateOptions: Ref<T.LeaveEndDateOption[]>;
+} => {
+  const state = reactive({
+    loadStatus: "idle" as "idle" | "loading" | "success" | "error",
+    startDateOptions: [] as T.LeaveStartDateOption[],
+    endDateOptions: [] as T.LeaveEndDateOption[],
+  });
+
+  // fetch data if needed
+  if (state.loadStatus === "idle") {
+    api
+      .getLeaveDateOptions()
+      .then((opts) => {
+        state.startDateOptions = opts.startDateOptions;
+        state.endDateOptions = opts.endDateOptions;
+        state.loadStatus = "success";
+      })
+      .catch((error) => {
+        state.loadStatus = "error";
+        throw new Error(error);
+      });
+  }
+
+  return toRefs(state);
+};

--- a/resources/js/icons/CalendarIcon.vue
+++ b/resources/js/icons/CalendarIcon.vue
@@ -1,0 +1,19 @@
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill="currentColor"
+      d="M5 22q-.825 0-1.412-.587T3 20V6q0-.825.588-1.412T5 4h1V2h2v2h8V2h2v2h1q.825 0 1.413.588T21 6v14q0 .825-.587 1.413T19 22zm0-2h14V10H5z"
+    ></path>
+  </svg>
+</template>
+
+<script lang="ts">
+export default {
+  name: "MaterialSymbolsCalendarToday",
+};
+</script>

--- a/resources/js/icons/index.ts
+++ b/resources/js/icons/index.ts
@@ -1,3 +1,4 @@
+export { default as CalendarIcon } from "./CalendarIcon.vue";
 export { default as CheckIcon } from "./CheckIcon.vue";
 export { default as ChevronUpDownIcon } from "./ChevronUpDownIcon.vue";
 export { default as ChevronDownIcon } from "./ChevronDownIcon.vue";

--- a/resources/js/pages/CoursePlanningPage/stores/useLeaveStore.ts
+++ b/resources/js/pages/CoursePlanningPage/stores/useLeaveStore.ts
@@ -7,12 +7,16 @@ import { groupBy, keyBy } from "lodash";
 interface LeaveStoreState {
   activeGroupId: T.Group["id"] | null;
   leaveLookup: Record<T.Leave["id"], T.Leave>;
+  startDateOptions: T.ApiLeaveDateOptions["startDateOptions"];
+  endDateOptions: T.ApiLeaveDateOptions["endDateOptions"];
 }
 
 export const useLeaveStore = defineStore("leave", () => {
   const state = reactive<LeaveStoreState>({
     activeGroupId: null,
     leaveLookup: {},
+    startDateOptions: [],
+    endDateOptions: [],
   });
 
   const getters = {
@@ -45,9 +49,12 @@ export const useLeaveStore = defineStore("leave", () => {
   };
 
   const actions = {
-    init(groupId: T.Group["id"]): Promise<void> {
+    init(groupId: T.Group["id"]) {
       state.activeGroupId = groupId;
-      return actions.fetchLeaves();
+      return Promise.all([
+        actions.fetchLeaves(),
+        actions.fetchLeaveDateOptions(),
+      ]);
     },
 
     async fetchLeaves() {
@@ -56,6 +63,13 @@ export const useLeaveStore = defineStore("leave", () => {
       }
       const leaves = await api.fetchLeavesForGroup(state.activeGroupId);
       state.leaveLookup = keyBy(leaves, "id");
+    },
+
+    async fetchLeaveDateOptions() {
+      const { startDateOptions, endDateOptions } =
+        await api.getLeaveDateOptions();
+      state.startDateOptions = startDateOptions;
+      state.endDateOptions = endDateOptions;
     },
   };
 

--- a/resources/js/stores/useUserStore.ts
+++ b/resources/js/stores/useUserStore.ts
@@ -92,7 +92,6 @@ function generateDateTermInfo(
     });
   }
 
-  console.log(dateTermInfoArr);
   return dateTermInfoArr;
 }
 export const useUserStore = defineStore("user", () => {

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -481,3 +481,19 @@ export interface ApiResourceItemPermissions {
   update: boolean;
   delete: boolean;
 }
+
+export interface LeaveStartDateOption {
+  date: ISODate;
+  label: string; // "Fall 2024"
+  isFirstTermOption: boolean;
+}
+
+export interface LeaveEndDateOption {
+  date: ISODate;
+  label: string; // "Fall 2024"
+  isLastTermOption: boolean;
+}
+export interface ApiLeaveDateOptions {
+  startDateOptions: LeaveStartDateOption[];
+  endDateOptions: LeaveEndDateOption[];
+}

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -495,3 +495,9 @@ export interface ApiLeaveDateOptions {
   startDateOptions: LeaveStartDateOption[];
   endDateOptions: LeaveEndDateOption[];
 }
+
+export interface DateWithTermAndWeekNum {
+  date: string;
+  term: string;
+  weekNumber: number;
+}

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -484,14 +484,12 @@ export interface ApiResourceItemPermissions {
 
 export interface LeaveStartDateOption {
   date: ISODate;
-  label: string; // "Fall 2024"
-  isFirstTermOption: boolean;
+  term: string; // "Fall 2024"
 }
 
 export interface LeaveEndDateOption {
   date: ISODate;
-  label: string; // "Fall 2024"
-  isLastTermOption: boolean;
+  term: string; // "Fall 2024"
 }
 export interface ApiLeaveDateOptions {
   startDateOptions: LeaveStartDateOption[];

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\ReportController;
 use App\Http\Controllers\LeavePermissionController;
 use App\Http\Controllers\CoursePermissionController;
 use App\Http\Controllers\GroupPermissionController;
+use App\Http\Controllers\LeaveController;
 
 Route::impersonate();
 
@@ -77,9 +78,11 @@ Route::group(['prefix' => '/api/', 'middleware' => 'auth'], function () {
     // Laravel thinks the singular of `leaves` is `leaf`
     // so instead of using a resource, just define the routes
     Route::post('leaves', 'LeaveController@store');
+    Route::get('leaves/dateOptions', [LeaveController::class, 'dateOptions']);
     Route::get('leaves/{leave}', 'LeaveController@show');
     Route::put('leaves/{leave}', 'LeaveController@update');
     Route::delete('leaves/{leave}', 'LeaveController@destroy');
+
     Route::get('users/{leaveOwner}/leaves', 'UserLeaveController@index');
 
     Route::get('reports/deptLeavesReport', [ReportController::class, 'deptLeavesReport']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,6 +493,35 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz"
   integrity sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.7.tgz#7602367795a390ff0662efd1c7ae8ca74e75fb12"
+  integrity sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==
+  dependencies:
+    "@floating-ui/utils" "^0.2.7"
+
+"@floating-ui/dom@^1.0.0":
+  version "1.6.10"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.10.tgz#b74c32f34a50336c86dcf1f1c845cf3a39e26d6f"
+  integrity sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.7"
+
+"@floating-ui/utils@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.7.tgz#d0ece53ce99ab5a8e37ebdfe5e32452a2bfc073e"
+  integrity sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==
+
+"@floating-ui/vue@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/vue/-/vue-1.1.4.tgz#1dd6905a58baaa9a84c44c2cf28e281f715957a1"
+  integrity sha512-ammH7T3vyCx7pmm9OF19Wc42zrGnUw0QvLoidgypWsCLJMtGXEwY7paYIHO+K+oLC3mbWpzIHzeTVienYenlNg==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+    "@floating-ui/utils" "^0.2.7"
+    vue-demi ">=0.13.0"
+
 "@headlessui/vue@^1.7.16":
   version "1.7.16"
   resolved "https://registry.yarnpkg.com/@headlessui/vue/-/vue-1.7.16.tgz#bdc9d32d329248910325539b99e6abfce0c69f89"
@@ -5041,6 +5070,11 @@ vite@^4.4.3:
     rollup "^3.25.2"
   optionalDependencies:
     fsevents "~2.3.2"
+
+vue-demi@>=0.13.0:
+  version "0.14.10"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
+  integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==
 
 vue-demi@>=0.14.5:
   version "0.14.5"


### PR DESCRIPTION
Ready for a round of feedback I think:

- adds a `/api/leaves/dateOptions` endpoint for getting a list of preferred start and end leave dates that align with the payroll calendar. Currently, it's just every 2 weeks starting FY 25.
- Adds ui for selecting dates from these date options. I went the combobox route so that users could search by term. The term's approximate week number is shown with the date choice.

![ScreenShot 2024-08-27 at 18 53 26@2x](https://github.com/user-attachments/assets/1237ca8a-ed66-4214-8fa1-e9b2a481e7d4)

Known issues:
- broken tests 
- editing a leave custom date that doesn't align with payroll dates, it shows a blank combobox
- "Week numbers" may not be quite right.

on dev for testing