### PR TITLE
Fix regression: some leaves do not appear in leave report (stacked on #193)

### DIFF
--- a/app/Library/Bandaid.php
+++ b/app/Library/Bandaid.php
@@ -242,16 +242,11 @@ class Bandaid {
     public function getTermsOverlappingDates($startDate, $endDate) {
         $terms = $this->getCLATerms();
 
-        // convert non-carbon dates to carbon
-        $startDate = $startDate instanceof Carbon ? $startDate : new Carbon($startDate);
-        $endDate = $endDate instanceof Carbon ? $endDate : new Carbon($endDate);
-
         return $terms->filter(function ($term) use ($startDate, $endDate) {
-
             $termStartDate = new Carbon($term->TERM_BEGIN_DT);
             $termEndDate = new Carbon($term->TERM_END_DT);
-            return $startDate->between($termStartDate, $termEndDate)
-                || $endDate->between($termStartDate, $termEndDate);
+            return $termStartDate->between($startDate, $endDate)
+                || $termEndDate->between($startDate, $endDate);
         });
     }
 

--- a/resources/js/pages/CoursePlanningPage/stores/useCoursePlanningStore.ts
+++ b/resources/js/pages/CoursePlanningPage/stores/useCoursePlanningStore.ts
@@ -407,7 +407,6 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
 
     setFiltersFromQueryString(parsedQuery: ReturnType<typeof qs.parse>) {
       const updatedFilters: T.CoursePlanningFilters = { ...state.filters };
-      console.log("parsed query", parsedQuery);
 
       if (parsedQuery.inPlanningMode) {
         updatedFilters.inPlanningMode = parsedQuery.inPlanningMode === "true";
@@ -457,8 +456,6 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
       }
 
       state.filters = updatedFilters;
-
-      console.log("parsed query", { parsedQuery, filters: updatedFilters });
     },
   };
 

--- a/resources/js/pages/CoursePlanningPage/stores/useLeaveStore.ts
+++ b/resources/js/pages/CoursePlanningPage/stores/useLeaveStore.ts
@@ -7,16 +7,12 @@ import { groupBy, keyBy } from "lodash";
 interface LeaveStoreState {
   activeGroupId: T.Group["id"] | null;
   leaveLookup: Record<T.Leave["id"], T.Leave>;
-  startDateOptions: T.ApiLeaveDateOptions["startDateOptions"];
-  endDateOptions: T.ApiLeaveDateOptions["endDateOptions"];
 }
 
 export const useLeaveStore = defineStore("leave", () => {
   const state = reactive<LeaveStoreState>({
     activeGroupId: null,
     leaveLookup: {},
-    startDateOptions: [],
-    endDateOptions: [],
   });
 
   const getters = {
@@ -51,10 +47,7 @@ export const useLeaveStore = defineStore("leave", () => {
   const actions = {
     init(groupId: T.Group["id"]) {
       state.activeGroupId = groupId;
-      return Promise.all([
-        actions.fetchLeaves(),
-        actions.fetchLeaveDateOptions(),
-      ]);
+      return Promise.all([actions.fetchLeaves()]);
     },
 
     async fetchLeaves() {
@@ -63,13 +56,6 @@ export const useLeaveStore = defineStore("leave", () => {
       }
       const leaves = await api.fetchLeavesForGroup(state.activeGroupId);
       state.leaveLookup = keyBy(leaves, "id");
-    },
-
-    async fetchLeaveDateOptions() {
-      const { startDateOptions, endDateOptions } =
-        await api.getTermPayrollDates();
-      state.startDateOptions = startDateOptions;
-      state.endDateOptions = endDateOptions;
     },
   };
 


### PR DESCRIPTION
Resolves an regression after #191  where some leaves would not appear in the dept leave report if they're leave start/end dates were in the liminal space between terms (like the term payroll leave dates).

Accidentally swapped the dates after #191, and then "fixed" the broken test by casting strings to Carbon object.