### PR TITLE
fix phpdocs for `getDeptClassList` and  `getTerms`

### DIFF
--- a/app/Library/Bandaid.php
+++ b/app/Library/Bandaid.php
@@ -130,7 +130,7 @@ class Bandaid {
      * Get all academic terms for CLA (undergrad and grad)
      * at the UMNTC
      *
-     * @return array<array{
+     * @return array<object{
      *   id: int,
      *   TERM: int,
      *   TERM_BEGIN_DT: string, // "2019-01-22"
@@ -181,7 +181,7 @@ class Bandaid {
     /**
      * Retrieves a list of course details.
      *
-     * @return array<array{
+     * @return array<object{
      *   id: int,
      *   TERM: int,
      *   INSTRUCTOR_EMPLID: int,


### PR DESCRIPTION
fixes angry red squiggles in vscode. `Bandaid::cachedGet` uses `json_decode` to parse body, with the default `false` option – which returns an object not and array. But, the PHPDocs indicate that an array is returned in some places, incorrect type error messages in vscode.