### PR TITLE
fix: leave remains in edit mode after save (stacked on #198)

### DIFF
--- a/resources/js/components/LeavesTable/LeaveTableRow.vue
+++ b/resources/js/components/LeavesTable/LeaveTableRow.vue
@@ -123,7 +123,8 @@
               userStore.saveLeave({
                 ...leave,
                 ...localLeave,
-              })
+              });
+              isEditing = false;
             "
           >
             Save

--- a/resources/js/components/LeavesTable/SelectLeaveDate.vue
+++ b/resources/js/components/LeavesTable/SelectLeaveDate.vue
@@ -43,7 +43,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { computed, ref, onMounted } from "vue";
+import { computed, ref, onMounted, watch } from "vue";
 import ComboBox, { ComboBoxOption } from "@/components/ComboBox.vue";
 import InputGroup from "../InputGroup.vue";
 import dayjs from "dayjs";
@@ -73,12 +73,6 @@ const showCustomDateInput = ref(false);
 const termPayrollDatesStore = useTermPayrollDatesStore();
 onMounted(async () => {
   await termPayrollDatesStore.init();
-
-  // once payroll dates are loaded, if modelValue is a
-  // custom date, show the custom date input
-  if (isCustomDate.value) {
-    showCustomDateInput.value = true;
-  }
 });
 
 const isCustomDate = computed(
@@ -103,6 +97,17 @@ const comboboxOptions = computed(() => {
     })
     .filter((option) => !props.isOptionDisabled(option));
 });
+
+// if combobox options update (e.g. when term payroll dates are loaded,
+// or the valid end dates change), re-check if the current modelValue
+// is a custom date and show the custom date input
+watch(
+  comboboxOptions,
+  () => {
+    showCustomDateInput.value = isCustomDate.value;
+  },
+  { immediate: true },
+);
 
 const localComboBoxValue = computed((): ComboBoxOption | null => {
   if (!props.modelValue) {


### PR DESCRIPTION
When editing a Leave, the end date will show with the "custom date input" even though it's a term date. This is because valid options change after component is mounted, either after loading, or after the start date is selected.

This changes from an onMounted check to watching when leave date options change.

on dev