### PR TITLE
fix: `Bandaid::getDepartments`

### DIFF
--- a/app/Library/Bandaid.php
+++ b/app/Library/Bandaid.php
@@ -64,7 +64,7 @@ class Bandaid {
     public function getDepartments(array $deptIds): array {
         try {
             $result = $this->cachedGet(
-                '/department/?' . urldecode(http_build_query(["deptId" => $deptIds]))
+                '/department?' . urldecode(http_build_query(["deptId" => $deptIds]))
             );
             return $result;
         } catch (RequestException $e) {


### PR DESCRIPTION
301 is returned from api because of the trailing `/`. We're not following redirects, so this error is thrown:
```
App\Library\Bandaid::getDepartments(): Return value must be of type array, null returned
```