### PR TITLE
fix: instructors with leave not appearing in leave report

### DIFF
--- a/resources/js/pages/CoursePlanningPage/stores/useCoursePlanningStore.ts
+++ b/resources/js/pages/CoursePlanningPage/stores/useCoursePlanningStore.ts
@@ -215,14 +215,9 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
           false
         );
 
-        const hasVisibleSection = methods.isPersonEnrolledInVisibleSection(
-          person.emplid,
-        );
-
         const isPersonVisible =
           hasVisibleRole &&
           isAcadApptVisible &&
-          hasVisibleSection &&
           (methods.isPersonMatchingSearch(person) ||
             methods.isPersonEnrolledInCourseMatchingSearch(person));
 


### PR DESCRIPTION
This adjusts the leave report filter logic to show instructors who have leaves, but may not have any taught sections that are visible (because of say, term filters).

removes the check to only show people with visible sections.

Resolves #203

On dev (tho the screenshot is from local)

![ScreenShot 2024-09-13 at 10 32 12@2x](https://github.com/user-attachments/assets/c49eca8c-9633-43f2-a927-b68431c70478)

