### PR TITLE
leave report: add filter for dept employee appt status

### DIFF
--- a/app/Http/Controllers/CoursePlanning/GroupPersonController.php
+++ b/app/Http/Controllers/CoursePlanning/GroupPersonController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\CoursePlanning;
 
 use App\Http\Controllers\Controller;
 use App\Group;
-use App\Http\Resources\PersonResource;
+use App\Http\Resources\DeptInstructorResource;
 use Illuminate\Http\Request;
 use App\Library\Bandaid;
 use App\Library\UserService;
@@ -23,8 +23,8 @@ class GroupPersonController extends Controller {
     public function index(Request $request, Group $group) {
         abort_unless($request->user()->can(Permissions::VIEW_PLANNED_COURSES) || $request->user()->managesGroup($group), 403);
 
-        $users = $this->userService->getDeptInstructors($group->dept_id);
+        $allDeptInstructors = $this->userService->getDeptInstructors($group->dept_id);
 
-        return PersonResource::collection($users);
+        return DeptInstructorResource::collection($allDeptInstructors);
     }
 }

--- a/app/Http/Resources/DeptInstructorResource.php
+++ b/app/Http/Resources/DeptInstructorResource.php
@@ -5,7 +5,7 @@ namespace App\Http\Resources;
 use Illuminate\Http\Resources\Json\JsonResource;
 use App\Library\Utilities;
 
-class PersonResource extends JsonResource {
+class DeptInstructorResource extends JsonResource {
     /**
      * Transform the resource into an array.
      *
@@ -22,6 +22,7 @@ class PersonResource extends JsonResource {
             'title' => $this->title,
             'leaveIds' => $this->leaveIds,
             'academicAppointment' => Utilities::trimWithFallback($this->jobCategory),
+            'hasActiveDeptAppointment' => $this->hasActiveDeptAppointment,
             'jobCode' => $this->jobCode,
             'emplid' => $this->emplid,
             'sslEligible' => $this->ssl_eligible,

--- a/resources/js/pages/CoursePlanningPage/CoursePlanningPage.vue
+++ b/resources/js/pages/CoursePlanningPage/CoursePlanningPage.vue
@@ -253,6 +253,13 @@ function handleTabChange(tab: Tab) {
 
   setTimeout(() => {
     coursePlanningStore.setIncludedEnrollmentRoles(tabRoleLookup[tab.id]);
+
+    // the default active appointment filter will mean that no TA's are shown
+    // so we need to change it to show all appointments if the tab is the TA tab
+    // not sure if this is the best way to do this... but it works
+    if (tab.id === "tas") {
+      coursePlanningStore.filters.onlyActiveAppointments = false;
+    }
   }, 0);
 }
 

--- a/resources/js/pages/CoursePlanningPage/components/CoursePlanningFilters.vue
+++ b/resources/js/pages/CoursePlanningPage/components/CoursePlanningFilters.vue
@@ -124,14 +124,35 @@
           <span class="tw-text-neutral-400 tw-text-xs ml-1">({{ count }})</span>
         </label>
       </fieldset>
-      <fieldset>
-        <div class="tw-flex tw-items-baseline tw-mb-1">
-          <legend
-            class="tw-uppercase tw-text-xs tw-text-neutral-500 tw-tracking-wide tw-font-semibold tw-my-1"
-          >
-            Minimum Enrollment
-          </legend>
-        </div>
+      <fieldset class="tw-flex tw-flex-col tw-text-sm tw-mt-1.5">
+        <legend
+          class="tw-uppercase tw-text-xs tw-text-neutral-500 tw-tracking-wide tw-font-semibold"
+        >
+          Appointment Status
+        </legend>
+        <label :class="{ active: filters.onlyActiveAppointments }">
+          <input
+            v-model="filters.onlyActiveAppointments"
+            type="radio"
+            :value="true"
+          />
+          Active
+        </label>
+        <label :class="{ active: !filters.onlyActiveAppointments }">
+          <input
+            v-model="filters.onlyActiveAppointments"
+            type="radio"
+            :value="false"
+          />
+          All
+        </label>
+      </fieldset>
+      <fieldset class="tw-mt-1.5">
+        <legend
+          class="tw-uppercase tw-text-xs tw-text-neutral-500 tw-tracking-wide tw-font-semibold tw-my-1"
+        >
+          Minimum Enrollment
+        </legend>
         <InputGroup
           v-model="minSectionEnrollmentRaw"
           label="Minimum Enrollment"

--- a/resources/js/pages/CoursePlanningPage/stores/useCoursePlanningStore.ts
+++ b/resources/js/pages/CoursePlanningPage/stores/useCoursePlanningStore.ts
@@ -47,6 +47,7 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
       excludedCourseLevels: new Set(),
       excludedAcadAppts: new Set(),
       includedEnrollmentRoles: new Set(["PI"]),
+      onlyActiveAppointments: true,
       minSectionEnrollment: 0,
       search: "",
     },
@@ -205,7 +206,9 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
       const isPersonVisibleLookupByEmplId: Record<T.Person["emplid"], boolean> =
         {};
 
-      const people = stores.personStore.allPeople;
+      const people = state.filters.onlyActiveAppointments
+        ? stores.personStore.peopleWithActiveAppointments
+        : stores.personStore.allPeople;
 
       people.forEach((person) => {
         const hasVisibleRole = methods.isPersonEnrolledWithVisibleRole(person);
@@ -730,6 +733,7 @@ export const useCoursePlanningStore = defineStore("coursePlanning", () => {
         excludedCourseLevels: new Set(),
         excludedAcadAppts: new Set(),
         includedEnrollmentRoles: new Set(["PI"]),
+        onlyActiveAppointments: true,
         minSectionEnrollment: 0,
         search: "",
       };

--- a/resources/js/pages/CoursePlanningPage/stores/usePersonStore.ts
+++ b/resources/js/pages/CoursePlanningPage/stores/usePersonStore.ts
@@ -24,6 +24,9 @@ export const usePersonStore = defineStore("person", () => {
       ) as T.Person[];
       return people.sort(sortByName);
     }),
+    peopleWithActiveAppointments: computed((): T.Person[] => {
+      return getters.allPeople.value.filter((p) => p.hasActiveDeptAppointment);
+    }),
     getPersonByEmplId: computed(
       () =>
         (emplId: T.Person["emplid"]): T.Person | null => {

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -235,6 +235,7 @@ export interface Person {
   emplid: number;
   title: string;
   jobCode: string;
+  hasActiveDeptAppointment: boolean;
   givenName: string;
   surName: string;
   displayName: string;
@@ -380,6 +381,7 @@ export interface CoursePlanningFilters {
   excludedAcadAppts: Set<string>;
   minSectionEnrollment: number;
   includedEnrollmentRoles: Set<EnrollmentRole>;
+  onlyActiveAppointments: boolean;
   search: string;
   inPlanningMode: boolean;
 }

--- a/tests/Feature/api/users/leaves/GetAllUserLeavesTest.php
+++ b/tests/Feature/api/users/leaves/GetAllUserLeavesTest.php
@@ -143,6 +143,10 @@ it('does not let BlueSheet Managers view leaves of instructors outside their gro
 
     $BANDAID_API = config('bandaid.baseUri');
     Http::fake([
+        // mock the getEmployeesForDept response, needed for checking
+        // whether the instructor has an active status
+        "{$BANDAID_API}/department/*/employees" => mockResponse("Bandaid/mockGetEmployeesForDept.json"),
+
         // Now, put the $instructor1 in the mock
         // reponse for getEmployeesForDept($deptId)
         "{$BANDAID_API}/classes/list/{$deptId}" => Http::response([


### PR DESCRIPTION
![ScreenShot 2024-09-13 at 13 04 56@2x](https://github.com/user-attachments/assets/27b56010-b1a1-4676-a7f3-437e06d9015d)

This adds a new filter to the Dept Leaves report, allowing users to choose whether to show only currently active dept employees or all department employees.

`UserService::getDeptInstructors()` is updated to add a new `hasActiveDeptAppointment` property to each instructor. The method adds an api request to Bandaid to get the current dept employee list, and then compares this active list with the list of all instructors. We could probably optimize this further (maybe just returning the active status directly from bandaid?) if needed.

On the frontend, the  a new `onlyActiveAppointments` filter is added to the course planning store. By default, this is true – only active instructors will be shown in the report. 

One gotcha was with the TA tab – the new 'only active' default seems to prevent any TA's from being shown (presumably because these TA's are not considered dept appointments). As a workaround, if a user clicks the TA tab, the filter will automatically change to "All". It's a little hacky, but simple and might be good enough – we could look at other solutions, tho.

Let me know if any labels or UI elements should change.

On dev.

Known issue: tests need to be updated.

Resolves #204 