### PR TITLE
fix: disappearing courses when changed

### DIFF
--- a/app/CourseSection.php
+++ b/app/CourseSection.php
@@ -35,10 +35,12 @@ class CourseSection extends Model implements CourseSectionInterface {
     }
 
     public function getApiId(): string {
+        // note: we're using a id field that remains fixed for the record
+        // even after updates to avoid issues when a user changes the term
+        // or course or instructor
         return join('-',[
-            $this->getCourseApiId(),
-            $this->class_section,
-            $this->term_id
+            'local-db',
+            $this->id,
         ]);
     }
 

--- a/app/Enrollment.php
+++ b/app/Enrollment.php
@@ -27,9 +27,12 @@ class Enrollment extends Model implements EnrollmentInterface {
     }
 
     public function getApiId(): string {
-        return join('_', [
-            $this->user->emplid,
-            $this->courseSection->getApiId(),
+        // note: we're using a id field that remains fixed for the record
+        // even after updates to avoid issues when a user changes the term
+        // or course or instructor
+        return join('-', [
+            'local-db',
+            $this->id,
         ]);
     }
 

--- a/tests/Feature/api/course-planning/CoursePlanningApiTest.php
+++ b/tests/Feature/api/course-planning/CoursePlanningApiTest.php
@@ -237,7 +237,7 @@ describe('GET /api/groups/:groupId/sections', function () {
         // expect that the unofficial section is included
         $sectionFromApi = collect($res->json())->firstWhere('courseId', $section->course_id);
         expect($sectionFromApi)->toEqual([
-            'id' => "TEST-1234-{$section->class_section}-{$section->term_id}",
+            'id' => "local-db-{$section->id}",
             'dbId' => $section->id,
             'courseId' => $section->course_id,
             'termId' => $section->term_id,


### PR DESCRIPTION
when a planned section/enrollment is changed, the id of that section might also change causing issues in the interface in planning mode (e.g. sections that disappear after course change).

This PR updates the api id for local courses so that it's stays stable on update.

(An alternative approach would have be to update the store and make sure old values are completely deleted and new values are added with the new id -- which might be better, but would require chasing down where we're relying on an old id.)

Fixes #211