### PR TITLE
fix(leaves report): spreadsheet doesn't use active status filter

### DIFF
--- a/resources/js/components/DownloadSpreadsheetButton.vue
+++ b/resources/js/components/DownloadSpreadsheetButton.vue
@@ -85,4 +85,3 @@ async function handleDownloadClick(): Promise<void> {
 }
 </script>
 <style scoped></style>
-@/utils/useSimulatedProgress

--- a/resources/js/pages/CoursePlanningPage/helpers/coursePlanningFilters.ts
+++ b/resources/js/pages/CoursePlanningPage/helpers/coursePlanningFilters.ts
@@ -48,7 +48,9 @@ export const allEnrollmentFiltersPass =
       filterSectionByPublishStateWhenNotInPlanningMode(filters)(
         enrollment.section,
       ) &&
-      filterEnrollmentByRole(filters)(enrollment.enrollment)
+      filterEnrollmentByRole(filters)(enrollment.enrollment) &&
+      filterPersonByAcadAppt(filters)(enrollment.person) &&
+      filterPersonByActiveDeptApptStatus(filters)(enrollment.person)
     );
   };
 

--- a/resources/js/pages/CoursePlanningPage/helpers/coursePlanningFilters.ts
+++ b/resources/js/pages/CoursePlanningPage/helpers/coursePlanningFilters.ts
@@ -25,6 +25,14 @@ export const filterPersonByAcadAppt =
     );
   };
 
+export const filterPersonByActiveDeptApptStatus =
+  (filters: T.CoursePlanningFilters) => (person: T.Person) => {
+    if (filters.onlyActiveAppointments) {
+      return person.hasActiveDeptAppointment;
+    }
+    return true;
+  };
+
 export const filterEnrollmentByRole =
   (filters: Pick<T.CoursePlanningFilters, "includedEnrollmentRoles">) =>
   (enrollment: T.Enrollment) => {

--- a/resources/js/pages/CoursePlanningPage/helpers/getListOfTermLeaves.ts
+++ b/resources/js/pages/CoursePlanningPage/helpers/getListOfTermLeaves.ts
@@ -1,6 +1,9 @@
 import * as T from "@/types";
 import { getLeavesInTerm } from "./getLeavesInTerm";
-import { filterPersonByAcadAppt } from "./coursePlanningFilters";
+import {
+  filterPersonByAcadAppt,
+  filterPersonByActiveDeptApptStatus,
+} from "./coursePlanningFilters";
 
 export function getListOfTermLeaves({
   lookups,
@@ -12,9 +15,12 @@ export function getListOfTermLeaves({
   return Object.values(lookups.termLookup).map((term) => {
     const leaves = getLeavesInTerm({ lookups, term });
 
-    // remove leaves for people with excluded academic appointments
     const filteredLeaves = leaves.filter((leave) => {
-      return filterPersonByAcadAppt(filters)(leave.person);
+      // remove leaves for people with excluded academic appointments
+      return (
+        filterPersonByAcadAppt(filters)(leave.person) &&
+        filterPersonByActiveDeptApptStatus(filters)(leave.person)
+      );
     });
 
     return { term, leaves: filteredLeaves };

--- a/resources/js/pages/CoursePlanningPage/helpers/getPersonTableRows.ts
+++ b/resources/js/pages/CoursePlanningPage/helpers/getPersonTableRows.ts
@@ -8,6 +8,7 @@ import {
   filterPersonByAcadAppt,
   filterPersonTableRowForAtLeastOneEnrollment,
   filterTermByStartAndEndTerm,
+  filterPersonByActiveDeptApptStatus,
 } from "./coursePlanningFilters";
 
 export function getPersonTableRows({
@@ -24,7 +25,12 @@ export function getPersonTableRows({
     (a, b) => a.id - b.id,
   );
 
-  const filteredPeople = sortedPeople.filter(filterPersonByAcadAppt(filters));
+  const matchedAcadAppt = filterPersonByAcadAppt(filters);
+  const matchesActiveInDeptStatus = filterPersonByActiveDeptApptStatus(filters);
+
+  const filteredPeople = sortedPeople.filter(
+    (person) => matchedAcadAppt(person) && matchesActiveInDeptStatus(person),
+  );
 
   const filteredTerms = sortedTerms.filter(
     filterTermByStartAndEndTerm(filters),


### PR DESCRIPTION
Use appointment status filter when creating the downloadable leaves report spreadsheet.

resolves #209 

