### PR TITLE
change combobox to use a distinct `add new option` input

### DIFF
--- a/resources/js/components/Button.vue
+++ b/resources/js/components/Button.vue
@@ -11,6 +11,8 @@
         variant === 'tertiary',
       'tw-border tw-border-red-500 tw-bg-transparent hover:tw-bg-bs-red tw-text-red-500 !tw-px-3 !tw-py-2':
         variant === 'danger',
+      'tw-text-bs-blue hover:!tw-underline hover:tw-text-bs-blue-dark tw-bg-transparent tw-border-none tw-p-0 tw-no-underline':
+        variant === 'link',
     }"
     v-bind="$attrs"
     :to="componentType === RouterLink ? to : undefined"
@@ -28,7 +30,7 @@ const props = withDefaults(
   defineProps<{
     href?: string;
     to?: RouteLocationRaw;
-    variant?: "primary" | "secondary" | "tertiary" | "danger";
+    variant?: "primary" | "secondary" | "tertiary" | "danger" | "link";
     type?: "button" | "submit" | "reset";
   }>(),
   {

--- a/resources/js/components/ComboBox/ComboBox.vue
+++ b/resources/js/components/ComboBox/ComboBox.vue
@@ -65,16 +65,24 @@
           class="combobox__options tw-border tw-border-neutral-300 tw-py-3 tw-px-2 tw-max-h-60 tw-overflow-auto tw-bg-white tw-rounded-md tw-shadow-lg tw-ring-1 tw-ring-black tw-ring-opacity-5 focus:tw-outline-none tw-relative tw-z-[1000] tw-min-w-[20rem]"
           :style="floatingStyles"
         >
+        <div class="tw-flex tw-justify-end">
           <button
             type="button"
-            class="tw-absolute tw-top-2 tw-right-2 tw-p-1 tw-text-neutral-400 hover:tw-text-neutral-600 tw-bg-transparent tw-border-none tw-cursor-pointer tw-rounded"
-            aria-label="Close"
+            class="tw-p-1 tw-text-neutral-400 hover:tw-text-neutral-600 tw-bg-transparent tw-border-none tw-cursor-pointer tw-rounded"
+            aria-label="Close options dropdown"
+            title="Close options dropdown"
             @click="closeComboBoxOptions"
           >
             <XIcon />
           </button>
+        </div>
+          <div v-if="!options.length">
+            <p class="tw-text-sm tw-text-neutral-500 tw-text-center">
+              No options.
+            </p>
+          </div>
           <ul
-            v-if="filteredOptions.length"
+            v-else-if="filteredOptions.length"
             :id="`combobox-${label}__options`"
             class="tw-pl-0 tw-flex tw-flex-col gap-2"
             role="listbox"

--- a/resources/js/components/ComboBox/ComboBox.vue
+++ b/resources/js/components/ComboBox/ComboBox.vue
@@ -65,6 +65,14 @@
           class="combobox__options tw-border tw-border-neutral-300 tw-py-3 tw-px-2 tw-max-h-60 tw-overflow-auto tw-bg-white tw-rounded-md tw-shadow-lg tw-ring-1 tw-ring-black tw-ring-opacity-5 focus:tw-outline-none tw-relative tw-z-[1000] tw-min-w-[20rem]"
           :style="floatingStyles"
         >
+          <button
+            type="button"
+            class="tw-absolute tw-top-2 tw-right-2 tw-p-1 tw-text-neutral-400 hover:tw-text-neutral-600 tw-bg-transparent tw-border-none tw-cursor-pointer tw-rounded"
+            aria-label="Close"
+            @click="closeComboBoxOptions"
+          >
+            <XIcon />
+          </button>
           <ul
             v-if="filteredOptions.length"
             :id="`combobox-${label}__options`"
@@ -86,7 +94,7 @@
             v-else
             class="tw-p-2 tw-text-neutral-500 tw-text-center"
           >
-            <p class="tw-text-sm">No matches found.</p>
+            <p class="tw-text-sm tw-mb-1">No matches found.</p>
             <p class="tw-text-sm">
               <Button
               v-if="query"
@@ -134,6 +142,7 @@ import { ComboBoxOptionType, ComboBoxOption } from ".";
 import { onClickOutside } from "@vueuse/core";
 import ChevronDownIcon from "@/icons/ChevronDownIcon.vue";
 import CheckIcon from "@/icons/CheckIcon.vue";
+import XIcon from "@/icons/XIcon.vue";
 import { first } from "lodash";
 import {
   useFloating,

--- a/resources/js/components/ComboBox/ComboBox.vue
+++ b/resources/js/components/ComboBox/ComboBox.vue
@@ -13,6 +13,7 @@
         v-if="modelValue && !areOptionsOpen"
         ref="selectedItemRef"
         class="tw-flex tw-bg-transparent tw-border tw-border-neutral-300 tw-w-full tw-py-3 tw-px-4 tw-items-center tw-justify-between tw-rounded-md tw-text-left"
+        :aria-label="`Change ${label}: ${modelValue.label} ${modelValue.secondaryLabel ? '(' + modelValue.secondaryLabel + ')' : ''}`"
         @click="handleChangeOption"
       >
         <div class="tw-flex tw-flex-col tw-items-start tw-flex-1">
@@ -44,11 +45,13 @@
           :aria-controls="`combobox-${label}__options`"
           aria-autocomplete="list"
           :aria-expanded="areOptionsOpen"
+          :aria-activedescendant="activeDescendantId"
           @keydown="handleKeyDown"
           @focus="areOptionsOpen = true"
         />
         <button
           class="tw-flex tw-items-center tw-justify-center tw-bg-transparent tw-border-none tw-p-2 tw-mr-2 tw-rounded-md"
+          :aria-label="areOptionsOpen ? 'Collapse options' : 'Expand options'"
           @click="areOptionsOpen = !areOptionsOpen"
         >
           <ChevronDownIcon
@@ -59,6 +62,7 @@
       </div>
 
       <MaybeTeleport :teleportTo="teleportTo">
+        <!-- see https://www.w3.org/WAI/ARIA/apg/patterns/combobox/#wai-ariaroles,states,andproperties -->
         <div
           v-if="areOptionsOpen"
           ref="comboboxOptionsRef"
@@ -90,7 +94,6 @@
             <ComboBoxOption
               v-for="option in filteredOptions"
               :key="option.id ?? option.label"
-              role="option"
               :option="option"
               :isSelected="isSelected(option)"
               :isHighlighted="isHighlighted(option)"
@@ -124,6 +127,7 @@
                 v-model="newOptionValue"
                 type="text"
                 placeholder="Add new option..."
+                aria-label="New option value"
                 class="tw-flex-1 tw-px-3 tw-py-2 tw-border tw-border-neutral-300 tw-rounded-md tw-text-sm focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-blue-500"
                 @keydown.enter="handleAddNewOptionsClick"
               />
@@ -218,6 +222,13 @@ const indexOfHighlightedOption = computed(() => {
     areOptionsEqual(option, highlightedOption.value),
   );
   return index === -1 ? null : index;
+});
+
+const activeDescendantId = computed(() => {
+  if (!highlightedOption.value) {
+    return undefined;
+  }
+  return `option-${highlightedOption.value.id ?? highlightedOption.value.label}`;
 });
 
 function areOptionsEqual(

--- a/resources/js/components/ComboBox/ComboBox.vue
+++ b/resources/js/components/ComboBox/ComboBox.vue
@@ -132,6 +132,7 @@
                 :disabled="!newOptionValue"
                 aria-label="Add new option"
                 title="Add new option"
+                data-cy="add-new-option-button"
                 @click="handleAddNewOptionsClick"
               >
                 <CheckIcon aria-hidden="true" />

--- a/resources/js/components/ComboBox/ComboBox.vue
+++ b/resources/js/components/ComboBox/ComboBox.vue
@@ -37,6 +37,7 @@
           :id="`combobox-${label}__input`"
           ref="comboboxInputRef"
           v-model="query"
+          type="search"
           class="tw-border-none tw-bg-transparent tw-block tw-w-full tw-py-3 tw-pl-4 tw-text-neutral-900 focus:tw-outline-none tw-text-sm flex-1"
           :placeholder="placeholder"
           role="combobox"
@@ -83,9 +84,20 @@
           </ul>
           <div
             v-else
-            class="tw-p-2 tw-text-neutral-500 tw-text-sm tw-text-center"
+            class="tw-p-2 tw-text-neutral-500 tw-text-center"
           >
-            None.
+            <p class="tw-text-sm">No matches found.</p>
+            <p class="tw-text-sm">
+              <Button
+              v-if="query"
+              variant="link"
+              type="button"
+              class="tw-inline-block"
+              @click="query = ''"
+            >
+              Clear
+            </Button>
+            to see all options.</p>
           </div>
           <div
             v-if="canAddNewOptions"
@@ -131,6 +143,7 @@ import {
 } from "@floating-ui/vue";
 import Label from "@/components/Label.vue";
 import MaybeTeleport from "@/components/MaybeTeleport.vue";
+import Button from "../Button.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -226,8 +239,8 @@ onClickOutside(comboboxContainerRef, () => {
 });
 
 function handleChangeOption() {
-  // begin with the currently selected option label
-  query.value = props.modelValue?.label ?? "";
+  // Clear the query to show all options when editing
+  query.value = "";
   highlightedOption.value = props.modelValue;
   areOptionsOpen.value = !areOptionsOpen.value;
   nextTick(() => {

--- a/resources/js/components/ComboBox/ComboBox.vue
+++ b/resources/js/components/ComboBox/ComboBox.vue
@@ -87,14 +87,29 @@
           >
             None.
           </div>
-          <Button
+          <div
             v-if="canAddNewOptions"
-            class="tw-w-full tw-items-center disabled:tw-opacity-40"
-            :disabled="!query || isQueryAnOption"
-            @click="handleAddNewOptionsClick"
+            class="tw-mt-3 tw-pt-3 tw-border-t tw-border-neutral-200"
           >
-            Add New Option
-          </Button>
+            <div class="tw-flex tw-gap-2 tw-items-center">
+              <input
+                v-model="newOptionValue"
+                type="text"
+                placeholder="Add new option..."
+                class="tw-flex-1 tw-px-3 tw-py-2 tw-border tw-border-neutral-300 tw-rounded-md tw-text-sm focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-blue-500"
+                @keydown.enter="handleAddNewOptionsClick"
+              />
+              <button
+                class="tw-flex tw-items-center tw-justify-center tw-w-9 tw-h-9 tw-bg-bs-blue tw-text-white tw-rounded-md hover:tw-bg-blue-600 disabled:tw-opacity-40 disabled:tw-cursor-not-allowed"
+                :disabled="!newOptionValue"
+                aria-label="Add new option"
+                title="Add new option"
+                @click="handleAddNewOptionsClick"
+              >
+                <CheckIcon aria-hidden="true" />
+              </button>
+            </div>
+          </div>
           <slot name="afterOptions" :query="query" />
         </div>
       </MaybeTeleport>
@@ -106,6 +121,7 @@ import { ref, computed, nextTick, watch } from "vue";
 import { ComboBoxOptionType, ComboBoxOption } from ".";
 import { onClickOutside } from "@vueuse/core";
 import ChevronDownIcon from "@/icons/ChevronDownIcon.vue";
+import CheckIcon from "@/icons/CheckIcon.vue";
 import { first } from "lodash";
 import {
   useFloating,
@@ -115,7 +131,6 @@ import {
 } from "@floating-ui/vue";
 import Label from "@/components/Label.vue";
 import MaybeTeleport from "@/components/MaybeTeleport.vue";
-import Button from "@/components/Button.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -151,6 +166,7 @@ const emit = defineEmits<{
 const query = ref("");
 const areOptionsOpen = ref(false);
 const highlightedOption = ref<ComboBoxOptionType | null>(null);
+const newOptionValue = ref("");
 
 const comboboxContainerRef = ref<HTMLElement | null>(null);
 const selectedItemRef = ref<HTMLElement | null>(null);
@@ -171,10 +187,6 @@ const indexOfHighlightedOption = computed(() => {
     areOptionsEqual(option, highlightedOption.value),
   );
   return index === -1 ? null : index;
-});
-
-const isQueryAnOption = computed(() => {
-  return filteredOptions.value.some((option) => option.label === query.value);
 });
 
 function areOptionsEqual(
@@ -260,27 +272,29 @@ function closeComboBoxOptions() {
 }
 
 function handleAddNewOptionsClick() {
-  if (!query.value) {
+  if (!newOptionValue.value) {
     return;
   }
 
   // check if the option already exists
   const existingOption = props.options.find(
-    (option) => option.label === query.value,
+    (option) => option.label === newOptionValue.value,
   );
 
   if (existingOption) {
     handleSelectOption(existingOption);
+    newOptionValue.value = "";
     return;
   }
 
   // if it doesn't exist, add it as a new option
   const newOption: ComboBoxOptionType = {
-    label: query.value,
+    label: newOptionValue.value,
   };
 
   emit("addNewOption", newOption);
   handleSelectOption(newOption);
+  newOptionValue.value = "";
 }
 
 function handleKeyDown(event: KeyboardEvent) {

--- a/resources/js/components/ComboBox/ComboBox.vue
+++ b/resources/js/components/ComboBox/ComboBox.vue
@@ -128,7 +128,7 @@
                 @keydown.enter="handleAddNewOptionsClick"
               />
               <button
-                class="tw-flex tw-items-center tw-justify-center tw-w-9 tw-h-9 tw-bg-bs-blue tw-text-white tw-rounded-md hover:tw-bg-blue-600 disabled:tw-opacity-40 disabled:tw-cursor-not-allowed"
+                class="tw-flex tw-items-center tw-justify-center tw-w-9 tw-h-9 tw-bg-bs-blue tw-border-none tw-text-white tw-rounded-md hover:tw-bg-blue-600 disabled:tw-opacity-40 disabled:tw-cursor-not-allowed"
                 :disabled="!newOptionValue"
                 aria-label="Add new option"
                 title="Add new option"

--- a/resources/js/components/ComboBox/ComboBoxOption.vue
+++ b/resources/js/components/ComboBox/ComboBoxOption.vue
@@ -3,6 +3,7 @@
     :id="`option-${option.id ?? option.label}`"
     ref="currentOption"
     class="tw-list-none"
+    :aria-selected="isSelected"
   >
     <div
       class="tw-flex tw-justify-between tw-items-center tw-rounded-md tw-cursor-pointer"

--- a/resources/js/components/ComboBox/ComboBoxOption.vue
+++ b/resources/js/components/ComboBox/ComboBoxOption.vue
@@ -3,6 +3,7 @@
     :id="`option-${option.id ?? option.label}`"
     ref="currentOption"
     class="tw-list-none"
+    role="option"
     :aria-selected="isSelected"
   >
     <div

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -15,6 +15,7 @@ module.exports = {
         "umn-neutral-800": `#262626`, // active text color
         "umn-neutral-900": `#1a1a1a`,
         "bs-blue": "#3490dc",
+        "bs-blue-dark": "#1d68a7",
       },
       backgroundImage: {
         striped:

--- a/tests/cypress/integration/groupCreation.test.ts
+++ b/tests/cypress/integration/groupCreation.test.ts
@@ -237,7 +237,26 @@ describe("Groups UI", () => {
       cy.visit(`/group/${groupId}`);
       cy.contains("Create Subgroup").click();
       cy.get("#groupName").type("Test Subgroup");
-      cy.get("#groupTypes input").type("Working Group{enter}");
+      cy.get("#groupTypes input").type("Working{enter}");
+
+      // should see that no options are available
+      cy.get(".combobox__options").contains("No options.");
+
+      // add a new option
+      cy.get(".combobox__options").within(() => {
+        cy.get("input").type("Working Group");
+        cy.get("[data-cy='add-new-option-button']").click();
+      });
+
+      // the new option should be selected
+      cy.get("#groupTypes").contains("Working Group").click();
+
+      // the option should be marked as selected within the option list
+      cy.get(".combobox__options [aria-selected=true]").contains("Working Group");
+
+      // close the options list
+      cy.get(".combobox__options button[aria-label='Close options dropdown']").click();
+
       cy.contains("Create Group").click();
 
       cy.get("[data-cy=child-groups]").contains("Test Subgroup").click();

--- a/tests/cypress/integration/groupCreation.test.ts
+++ b/tests/cypress/integration/groupCreation.test.ts
@@ -25,7 +25,26 @@ describe("Groups UI", () => {
       cy.visit("/");
       cy.get(".app-header").contains("Create Group").click();
       cy.get("#groupName").type("Test Group");
-      cy.get("#groupTypes input").type("Committee{enter}");
+      cy.get("#groupTypes input").type("Comm{enter}");
+
+      // should see that no options are available
+      cy.get(".combobox__options").contains("No options.");
+
+      // add a new option
+      cy.get(".combobox__options").within(() => {
+        cy.get("input").type("Committee");
+        cy.get("[data-cy='add-new-option-button']").click();
+      });
+
+      // the new option should be selected
+      cy.get("#groupTypes").contains("Committee").click();
+
+      // the option should be marked as selected within the option list
+      cy.get(".combobox__options [aria-selected=true]").contains("Committee");
+
+      // close the options list
+      cy.get(".combobox__options button[aria-label='Close options dropdown']").click();
+
       cy.get("#parentOrganization").select("CLA");
       cy.get(".btn").contains("Create Group").click();
       cy.contains("Test Group");


### PR DESCRIPTION
This improves the accessibility, usability, and user experience of the `ComboBox` component to address some UX confusion about creating new options. (see #219)

### Previous Combobox:
<img width="458" height="247" alt="Screenshot From 2025-10-13 13-25-00" src="https://github.com/user-attachments/assets/85e23bc8-e75f-4e25-bc58-d7d2c9c85e34" />

- Only filtered options shown when opened, not all because the filter is set to the selected value (e.g. "Member")
- The "Add new" button is disabled because the value in the input ("Member") not a new option. It's unclear how to enable the button.
- Even when enabled, it's unclear that the "Add new option" button is using the filter field as an input since they're not close it each other.

### Updated Combobox:
 <img width="455" height="405" alt="Screenshot From 2025-10-13 13-23-25" src="https://github.com/user-attachments/assets/fcca9a78-eb64-4c22-9ad0-f520d4b1e311" />

- Clears filter when opened so all options show when opened
- Adds a separate input to "Add new option..."
---

### Also:
- added aria attributes and improved screenreader support.
- clarified messages during empty states.
- added "close" button to the options list a workaround for an issue where the options list could be left opened if it gained focus and the user navigated away without selecting a value.
- updates tests to work with updated combobox

On dev for testing.

Resolves #219