### PR TITLE
harden our reminder mailing

### DIFF
--- a/app/Console/Commands/sendPeriodicUpdateEmail.php
+++ b/app/Console/Commands/sendPeriodicUpdateEmail.php
@@ -4,6 +4,8 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class sendPeriodicUpdateEmail extends Command
 {
@@ -38,24 +40,85 @@ class sendPeriodicUpdateEmail extends Command
      */
     public function handle()
     {
-        $users = \App\User::where("send_email_reminders", 1)->get();
-        foreach($users as $user) {
-            $userGroups = $user->groups->filter(function ($group) use ($user) {
-                $activeMembers = $group->activeMembers->filter(function($member) use ($user) {
-                    return $member->user->id == $user->id;
-                });
-                $adminRoles = $activeMembers->filter(function($member) {
-                    return $member->admin;
-                });
-                return $adminRoles->count() > 0;
-            });
-            // should be groups where we're an admin
-            if($userGroups->count() > 0) {
-                $uniqueGroups = $userGroups->unique('id');
-                Mail::to($user->email)->send(new \App\Mail\GroupUpdateReminder($uniqueGroups));
-            }
-            
+        $processed = 0;
+        $queued = 0;
+        $sent = 0;
+        $skippedNoEmail = 0;
+        $skippedInvalidEmail = 0;
+        $failed = 0;
 
-        }
+        \App\User::where("send_email_reminders", 1)
+            ->chunkById(200, function ($users) use (&$processed, &$queued, &$sent, &$skippedNoEmail, &$skippedInvalidEmail, &$failed) {
+                foreach ($users as $user) {
+                    $processed++;
+
+                    $email = trim((string) $user->email);
+                    if ($email === '') {
+                        $skippedNoEmail++;
+                        continue;
+                    }
+
+                    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                        $skippedInvalidEmail++;
+                        Log::warning('Skipping periodic update reminder due to invalid email.', [
+                            'user_id' => $user->id,
+                            'email' => $email,
+                        ]);
+                        continue;
+                    }
+
+                    $userGroups = $user->groups->filter(function ($group) use ($user) {
+                        $activeMembers = $group->activeMembers->filter(function ($member) use ($user) {
+                            return $member->user->id == $user->id;
+                        });
+                        $adminRoles = $activeMembers->filter(function ($member) {
+                            return $member->admin;
+                        });
+                        return $adminRoles->count() > 0;
+                    });
+
+                    // Only send reminders for groups where the user is an admin.
+                    if ($userGroups->count() === 0) {
+                        continue;
+                    }
+
+                    $uniqueGroups = $userGroups->unique('id');
+
+                    try {
+                        Mail::to($email)->queue(new \App\Mail\GroupUpdateReminder($uniqueGroups));
+                        $queued++;
+                    } catch (Throwable $queueException) {
+                        Log::warning('Queueing periodic update reminder failed. Falling back to direct send.', [
+                            'user_id' => $user->id,
+                            'email' => $email,
+                            'error' => $queueException->getMessage(),
+                        ]);
+
+                        try {
+                            Mail::to($email)->send(new \App\Mail\GroupUpdateReminder($uniqueGroups));
+                            $sent++;
+                        } catch (Throwable $sendException) {
+                            $failed++;
+                            Log::error('Sending periodic update reminder failed.', [
+                                'user_id' => $user->id,
+                                'email' => $email,
+                                'error' => $sendException->getMessage(),
+                            ]);
+                        }
+                    }
+                }
+            });
+
+        $this->info(sprintf(
+            'Periodic update reminders processed=%d queued=%d sent=%d skipped_no_email=%d skipped_invalid_email=%d failed=%d',
+            $processed,
+            $queued,
+            $sent,
+            $skippedNoEmail,
+            $skippedInvalidEmail,
+            $failed
+        ));
+
+        return self::SUCCESS;
     }
 }

--- a/app/Mail/GroupUpdateReminder.php
+++ b/app/Mail/GroupUpdateReminder.php
@@ -7,9 +7,16 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
 
-class GroupUpdateReminder extends Mailable
+class GroupUpdateReminder extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
+
+    public $tries = 3;
+
+    public $backoff = [60, 300, 900];
+
+    public $timeout = 120;
+
     public $userGroups;
     /**
      * Create a new message instance.


### PR DESCRIPTION
Our periodic reminder emails would fail if the target email no longer existed in the system, or the mail server experienced problems. This moves to a queue model and adds better error handling, so one failure won't prevent the batch from succeeding. 